### PR TITLE
Add auto collapse feature to sidebar

### DIFF
--- a/src/RootWindow.qml
+++ b/src/RootWindow.qml
@@ -42,7 +42,7 @@ ApplicationWindow {
 
         property bool intro: true
         property bool singleApplication: true
-        property bool autoCollapseSidebar: true
+        property bool autoCollapseSidebar: true   
     }
 
     Settings {

--- a/src/RootWindow.qml
+++ b/src/RootWindow.qml
@@ -42,6 +42,7 @@ ApplicationWindow {
 
         property bool intro: true
         property bool singleApplication: true
+        property bool autoCollapseSidebar: true
     }
 
     Settings {

--- a/src/SettingsDialog.qml
+++ b/src/SettingsDialog.qml
@@ -23,11 +23,18 @@ Dialog {
             title: qsTr("General")
 
             Layout.fillWidth: true
+            ColumnLayout {
+                 width: parent.width
+                CheckBox {
+                    id: singleApplicationCheckBox
 
-            CheckBox {
-                id: singleApplicationCheckBox
+                    text: qsTr("Allow running multiple application instances")
+                }
+                CheckBox {
+                    id: autoCollapseSidebarCheckBox
 
-                text: qsTr("Allow running multiple application instances")
+                    text: qsTr("Automatically collapse sidebar")
+                }
             }
         }
 
@@ -63,7 +70,10 @@ Dialog {
     function loadSettings() {
         // Single application
         singleApplicationCheckBox.checked = !generalSettings.singleApplication;
-
+        
+        //Auto collapse sidebar option
+        autoCollapseSidebarCheckBox.checked = generalSettings.autoCollapseSidebar;
+        
         // Preset indicator
         presetIndicatorCheckBox.checked = layoutsCollectionSettings.presetIndicator;
 
@@ -81,7 +91,10 @@ Dialog {
     function saveSettings() {
         // Single application
         generalSettings.singleApplication = !singleApplicationCheckBox.checked;
-
+        
+        //Auto collapse sidebar option
+        generalSettings.autoCollapseSidebar = autoCollapseSidebarCheckBox.checked;
+        
         // Preset indicator
         layoutsCollectionSettings.presetIndicator = presetIndicatorCheckBox.checked;
 

--- a/src/SettingsDialog.qml
+++ b/src/SettingsDialog.qml
@@ -33,7 +33,7 @@ Dialog {
                 CheckBox {
                     id: autoCollapseSidebarCheckBox
 
-                    text: qsTr("Automatically collapse sidebar")
+                    text: qsTr("Automatically collapse sidebar") 
                 }
             }
         }

--- a/src/SideBar.qml
+++ b/src/SideBar.qml
@@ -86,8 +86,10 @@ FocusScope {
             onContainsMouseChanged: {
                 if (containsMouse) {
                     delayOpenningTimer.start();
+                    delayAutoCloseTimer.stop();
                 } else {
                     delayOpenningTimer.stop();
+                    delayAutoCloseTimer.start();
                 }
             }
 
@@ -100,6 +102,19 @@ FocusScope {
                     if (rootSideBar.state === SideBar.Compact) {
                         rootSideBar.state = SideBar.Popup
                         rootSideBar.forceActiveFocus();
+                    }
+                }
+            }
+            Timer {
+                id: delayAutoCloseTimer
+
+                interval: 1500
+
+                onTriggered: {
+                    if (generalSettings.autoCollapseSidebar &&
+                        rootSideBar.state === SideBar.Popup) {
+                        rootSideBar.state = SideBar.Compact
+                        //rootSideBar.forceActiveFocus();
                     }
                 }
             }

--- a/src/SideBar.qml
+++ b/src/SideBar.qml
@@ -113,8 +113,7 @@ FocusScope {
                 onTriggered: {
                     if (generalSettings.autoCollapseSidebar &&
                         rootSideBar.state === SideBar.Popup) {
-                        rootSideBar.state = SideBar.Compact
-                        //rootSideBar.forceActiveFocus();
+                        rootSideBar.state = SideBar.Compact;                        
                     }
                 }
             }


### PR DESCRIPTION
Adds the ability to configure the sidebar to automatically collapse after it has been opened by mouse hover event.
Sidebar will collapse after mouse leaves the sidebar for 1.5 seconds.
Configuration item was added to setting dialog to enable this feature.