### PR TITLE
Fix for button text color when DE uses dark color scheme

### DIFF
--- a/src/imports/CCTV_Viewer/Themes/Compact/Button.qml
+++ b/src/imports/CCTV_Viewer/Themes/Compact/Button.qml
@@ -66,7 +66,7 @@ T.Button {
         text: control.text
         font: control.font
         color: control.checked || control.highlighted ? control.palette.brightText :
-               control.flat && !control.down ? (control.visualFocus ? control.palette.highlight : control.palette.windowText) : control.palette.buttonText
+               control.flat && !control.down ? (control.visualFocus ? control.palette.highlight : control.palette.windowText) : control.palette.dark
     }
 
     background: Rectangle {


### PR DESCRIPTION
Previously the theme used the DE's button text color, while the button background is set to a fixed light color.  When DE is configured for dark theme it assigns a light color to buttonText which caused it to display light text on a light button.

Since we are overriding the button background color anyway, we might as well do the same with the text color.