### PR TITLE
Update README.md for submodule clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@
 
 CCTV Viewer - a simple application for simultaneously viewing multiple video streams. Designed for high performance and low latency.
 Based on ffmpeg.
+
+To clone this repository be sure to use the following command:
+
+	git clone --recurse-submodules https://github.com/iEvgeny/cctv-viewer.git


### PR DESCRIPTION
Adding the command required to clone the entire repository with submodules makes it less likely to error out when building.