### PR TITLE
Selection frame

### DIFF
--- a/src/ViewportsLayout.qml
+++ b/src/ViewportsLayout.qml
@@ -2,6 +2,7 @@ import QtQml 2.12
 import QtQuick 2.12
 import QtQuick.Layouts 1.12
 import QtMultimedia 5.12
+import CCTV_Viewer.Core 1.0
 import CCTV_Viewer.Utils 1.0
 import CCTV_Viewer.Models 1.0
 
@@ -485,7 +486,7 @@ FocusScope {
                         states: [
                             State {
                                 name: "active"
-                                when: viewport.activeFocus
+                                when: viewport.activeFocus && !Context.config.kioskMode
 
                                 PropertyChanges {
                                     target: selectionFrame


### PR DESCRIPTION
It doesn't seem to make sense at this point.
If you are using kiosk mode, precisely to avoid accessing the settings of any viewport, having a visual identifier of the selected viewport may be unnecessary.