### PR TITLE
Add ONVIF, batch import/export, auto-adapt resolution, per-channel audio, and snap-free Debian install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050F00)
 #    endif()
 #endif()
 
-set(QT_LINK_DEPENDENCIES Core Quick Multimedia)
+set(QT_LINK_DEPENDENCIES Core Network Quick Multimedia)
 
 if (ANDROID)
     list(APPEND QT_LINK_DEPENDENCIES Svg)
@@ -157,6 +157,8 @@ set(PROJ_FILES
     src/singleapplication.h
     src/config.cpp src/config.h
     src/context.cpp src/context.h
+    src/fileio.cpp src/fileio.h
+    src/onvif.cpp src/onvif.h
     src/eventfilter.h src/eventfilter.cpp
     src/viewportslayoutmodel.cpp src/viewportslayoutmodel.h
     src/viewportslayoutscollectionmodel.cpp src/viewportslayoutscollectionmodel.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 set(VER_MAJ 0)
 set(VER_MIN 1)
-set(VER_PAT 9)
+set(VER_PAT 10)
 set(REL_STATUS "alpha")
 
 set(APP_NAME "CCTV Viewer")
@@ -15,7 +15,7 @@ if(${VER_PAT} GREATER 0)
     set(VERSION "${VERSION}.${VER_PAT}")
 endif()
 
-project(cctv-viewer VERSION ${VERSION} HOMEPAGE_URL "https://github.com/iEvgeny/cctv-viewer" LANGUAGES C CXX)
+project(cctv-viewer VERSION ${VERSION} HOMEPAGE_URL "https://github.com/jahedcuet/cctv-viewer" LANGUAGES C CXX)
 
 if(DEFINED REL_STATUS)
     set(VERSION "${VERSION}-${REL_STATUS}")

--- a/README.md
+++ b/README.md
@@ -11,3 +11,58 @@ Based on ffmpeg.
 To clone this repository be sure to use the following command:
 
 	git clone --recurse-submodules https://github.com/iEvgeny/cctv-viewer.git
+
+## Features
+
+* Simultaneous viewing of multiple video streams in a customizable grid.
+* **ONVIF support** — add an ONVIF camera or an NVR/DVR by IP address. NVRs/DVRs
+  expose many channels behind a single IP; every channel is detected and can be
+  added individually. Devices on the local network can be auto-discovered
+  (WS-Discovery).
+* **Auto adapting resolution** — the low-resolution sub stream is used in the
+  grid view and the application automatically switches to the high-resolution
+  main stream when a viewport is maximized (full screen or single 1×1 view).
+* **Audio** from cameras and NVR channels, with a mute toggle and a volume
+  slider available on every audio-capable channel (both on-screen, on hover,
+  and in the sidebar).
+* **Batch import / export** of all presets and sources to a single JSON file.
+* Presets, geometry/aspect-ratio control, cell merging, kiosk mode and more.
+
+### Adding an ONVIF camera or NVR/DVR
+
+1. Open the sidebar and expand **Sources → ONVIF → Add camera / NVR…**.
+2. Either press **Discover** to scan the local network, or type the device
+   **host/IP**, **port** and **credentials** and press **Connect**.
+3. The detected channels are listed with their main/sub stream resolutions.
+   Select the ones you want and press **Add selected to layout** — they fill the
+   free viewports of the current preset.
+
+### Batch import / export
+
+Use **Sources → Batch → Export…** to save every preset and its sources to a
+JSON file, and **Import…** to restore them on another machine.
+
+## Installing on Debian / Ubuntu (without snap)
+
+Two script-based options are provided for installing from source without snap.
+
+### Option A — build and install directly
+
+```sh
+git clone --recurse-submodules https://github.com/iEvgeny/cctv-viewer.git
+cd cctv-viewer
+./install-debian.sh
+```
+
+This installs the build/runtime dependencies, builds the application with CMake
+and installs it into `/usr`. To remove it later run `./install-debian.sh --uninstall`.
+
+### Option B — build a .deb package
+
+```sh
+cd cctv-viewer
+./make-deb.sh
+sudo apt install ../cctv-viewer_*.deb
+```
+
+Both scripts require `sudo` privileges to install packages.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![cctv-viewer](https://img.shields.io/badge/Launchpad_PPA-daily/latest+git-0e8420?logo=launchpad)](https://launchpad.net/~ievgeny/+archive/ubuntu/cctv-viewer)
-[![cctv-viewer](https://snapcraft.io/cctv-viewer/badge.svg)](https://snapcraft.io/cctv-viewer)
-[![cctv-viewer](https://snapcraft.io/cctv-viewer/trending.svg?name=0)](https://snapcraft.io/cctv-viewer)
+
 
 # CCTV Viewer
 
@@ -10,7 +8,7 @@ Based on ffmpeg.
 
 To clone this repository be sure to use the following command:
 
-	git clone --recurse-submodules https://github.com/iEvgeny/cctv-viewer.git
+	git clone --recurse-submodules https://github.com/jahedcuet/cctv-viewer.git
 
 ## Features
 
@@ -54,7 +52,7 @@ Two script-based options are provided for installing from source without snap.
 ### Option A — build and install directly
 
 ```sh
-git clone --recurse-submodules https://github.com/iEvgeny/cctv-viewer.git
+git clone --recurse-submodules https://github.com/jahedcuet/cctv-viewer.git
 cd cctv-viewer
 ./install-debian.sh
 ```

--- a/README.md
+++ b/README.md
@@ -17,22 +17,27 @@ To clone this repository be sure to use the following command:
 * Simultaneous viewing of multiple video streams in a customizable grid.
 * **ONVIF support** — add an ONVIF camera or an NVR/DVR by IP address. NVRs/DVRs
   expose many channels behind a single IP; every channel is detected and can be
-  added individually. Devices on the local network can be auto-discovered
-  (WS-Discovery).
+  added individually. Devices can be auto-discovered on the local network
+  (WS-Discovery) or by scanning any subnet/IP range (unicast) for remote add.
+* **Manual RTSP entry** with separate **main-stream** and **sub-stream** URL
+  fields per viewport.
 * **Auto adapting resolution** — the low-resolution sub stream is used in the
   grid view and the application automatically switches to the high-resolution
   main stream when a viewport is maximized (full screen or single 1×1 view).
 * **Audio** from cameras and NVR channels, with a mute toggle and a volume
   slider available on every audio-capable channel (both on-screen, on hover,
-  and in the sidebar).
+  and in the sidebar). A **master mute** button (Ctrl+M) silences everything,
+  and a speaker badge highlights which viewport is currently generating sound.
 * **Batch import / export** of all presets and sources to a single JSON file.
 * Presets, geometry/aspect-ratio control, cell merging, kiosk mode and more.
 
 ### Adding an ONVIF camera or NVR/DVR
 
 1. Open the sidebar and expand **Sources → ONVIF → Add camera / NVR…**.
-2. Either press **Discover** to scan the local network, or type the device
-   **host/IP**, **port** and **credentials** and press **Connect**.
+2. Either press **Discover** to scan the local network, enter a **Subnet**
+   (e.g. `192.168.1.0/24` or `10.0.0.1-10.0.0.50`) and press **Scan subnet**
+   to find devices on a remote/routed network, or type the device **host/IP**,
+   **port** and **credentials** and press **Connect**.
 3. The detected channels are listed with their main/sub stream resolutions.
    Select the ones you want and press **Add selected to layout** — they fill the
    free viewports of the current preset.

--- a/cctv-viewer.qrc
+++ b/cctv-viewer.qrc
@@ -4,6 +4,7 @@
         <file>translations/cctv-viewer_ru_RU.qm</file>
         <file>src/RootWindow.qml</file>
         <file>src/SettingsDialog.qml</file>
+        <file>src/OnvifDialog.qml</file>
         <file>src/Player.qml</file>
         <file>src/ViewportsLayout.qml</file>
         <file>src/SideBar.qml</file>
@@ -31,6 +32,9 @@
         <file>src/PresetIndicator.qml</file>
         <file>images/play.svg</file>
         <file>images/pause.svg</file>
+        <file>images/menu-sources.svg</file>
+        <file>images/volume.svg</file>
+        <file>images/volume-mute.svg</file>
         <file>src/CursorShape.qml</file>
     </qresource>
 </RCC>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,14 @@
 cctv-viewer (0.1.10-0) jammy; urgency=medium
 
   * Add ONVIF support for cameras and NVR/DVR multi-channel devices
-  * Add WS-Discovery scanning of ONVIF devices on the local network
+  * Add WS-Discovery (local) and unicast subnet scanning of ONVIF devices
+  * Add separate main-stream and sub-stream URL fields for manual RTSP entry
   * Auto adapt resolution: sub stream in grid, main stream when maximized
   * Add audio mute toggle and volume slider on every audio-capable channel
+  * Add a master mute button and a speaker badge on sounding viewports
   * Add batch import/export of presets and sources to JSON
-  * Add install-debian.sh and build-deb.sh for snap-free installation
+  * Add install-debian.sh and make-deb.sh for snap-free installation
+  * New application icon
 
  -- Evgeny S Maksimov <admin@vragam.net>  Mon, 14 Jul 2025 12:00:00 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
 cctv-viewer (0.1.10-0) jammy; urgency=medium
 
   * Add ONVIF support for cameras and NVR/DVR multi-channel devices
+  * Answer HTTP Basic/Digest auth challenges (fixes Hikvision "Host requires
+    authentication") and fix the WS-Security timestamp
+  * Add a selectable video fit mode (Stretch/Fit/Fill) to auto-fit streams
   * Add WS-Discovery (local) and unicast subnet scanning of ONVIF devices
   * Add separate main-stream and sub-stream URL fields for manual RTSP entry
   * Auto adapt resolution: sub stream in grid, main stream when maximized

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,8 @@ cctv-viewer (0.1.10-0) jammy; urgency=medium
   * Add ONVIF support for cameras and NVR/DVR multi-channel devices
   * Answer HTTP Basic/Digest auth challenges (fixes Hikvision "Host requires
     authentication") and fix the WS-Security timestamp
+  * Robust main/sub stream pairing so ONVIF adds now autofill the sub stream
+    (source-token, then name-based pairing) for low-load grid playback
   * Add a selectable video fit mode (Stretch/Fit/Fill) to auto-fit streams
   * Add WS-Discovery (local) and unicast subnet scanning of ONVIF devices
   * Add separate main-stream and sub-stream URL fields for manual RTSP entry

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ cctv-viewer (0.1.10-0) jammy; urgency=medium
   * Robust main/sub stream pairing so ONVIF adds now autofill the sub stream
     (source-token, then name-based pairing) for low-load grid playback
   * Add a selectable video fit mode (Stretch/Fit/Fill) to auto-fit streams
+  * Pause hidden viewports ~3s after one goes full screen to save bandwidth
   * Add WS-Discovery (local) and unicast subnet scanning of ONVIF devices
   * Add separate main-stream and sub-stream URL fields for manual RTSP entry
   * Auto adapt resolution: sub stream in grid, main stream when maximized

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+cctv-viewer (0.1.10-0) jammy; urgency=medium
+
+  * Add ONVIF support for cameras and NVR/DVR multi-channel devices
+  * Add WS-Discovery scanning of ONVIF devices on the local network
+  * Auto adapt resolution: sub stream in grid, main stream when maximized
+  * Add audio mute toggle and volume slider on every audio-capable channel
+  * Add batch import/export of presets and sources to JSON
+  * Add install-debian.sh and build-deb.sh for snap-free installation
+
+ -- Evgeny S Maksimov <admin@vragam.net>  Mon, 14 Jul 2025 12:00:00 +0300
+
 cctv-viewer (0.1.9-0) jammy; urgency=medium
 
   * Deep refactoring

--- a/debian/control
+++ b/debian/control
@@ -32,10 +32,12 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
          qml-module-qtqml-models2,
          qml-module-qtquick-controls,
          qml-module-qtquick-controls2,
+         qml-module-qtquick-templates2,
          qml-module-qtquick-window2,
          qml-module-qtquick-dialogs,
          qml-module-qt-labs-settings,
-         qml-module-qtmultimedia
+         qml-module-qtmultimedia,
+         qml-module-qtgraphicaleffects
 Description: CCTV Viewer - viewer and mounter video streams.
  A simple application for simultaneously viewing multiple video streams.
  Designed for high performance and low latency. Based on ffmpeg.

--- a/images/cctv-viewer.svg
+++ b/images/cctv-viewer.svg
@@ -1,233 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   id="svg4375"
-   viewBox="0 0 240 240"
-   height="256"
-   width="256">
-  <defs
-     id="defs4377">
-    <linearGradient
-       id="linearGradient1361">
-      <stop
-         style="stop-color:#f02f00;stop-opacity:1"
-         offset="0"
-         id="stop1357" />
-      <stop
-         style="stop-color:#e62600;stop-opacity:1"
-         offset="1"
-         id="stop1359" />
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 240 240" width="256" height="256">
+  <defs>
+    <linearGradient id="cctvBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1ab2d6"/>
+      <stop offset="1" stop-color="#0c5f74"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient15756">
-      <stop
-         style="stop-color:#ff7e5f;stop-opacity:1"
-         offset="0"
-         id="stop15750" />
-      <stop
-         id="stop15752"
-         offset="0.35259765"
-         style="stop-color:#ff7e5f;stop-opacity:0.6156863" />
-      <stop
-         style="stop-color:#ff7e5f;stop-opacity:0"
-         offset="1"
-         id="stop15754" />
+    <linearGradient id="cctvBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#d7e9ef"/>
     </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1621-1">
-      <path
-         id="path1623-7"
-         style="fill:none;stroke:#000000;stroke-width:1.875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         d="m 1141.1114,1079.62 -122.7437,212.5984 h 245.4874 z" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1966">
-      <path
-         d="m 1141.1114,1079.62 -122.7437,212.5984 h 245.4874 z"
-         style="fill:none;stroke:#000000;stroke-width:1.875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path1968" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1966-4">
-      <path
-         d="m 1141.1114,1079.62 -122.7437,212.5984 h 245.4874 z"
-         style="fill:none;stroke:#000000;stroke-width:1.875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path1968-3" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath2215-5">
-      <path
-         d="m 1635.9032,497.22996 -122.7437,212.59839 h 245.4874 z"
-         style="fill:none;stroke:#000000;stroke-width:1.875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2217-1" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath2219-1">
-      <path
-         d="M 1142.5477,500.96751 1019.804,713.5659 h 245.4874 z"
-         style="fill:none;stroke:#000000;stroke-width:1.875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2221-0" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath2564">
-      <path
-         d="M 1263.8515,1289.5536 1141.1078,1076.9552 1018.364,1289.5536 Z"
-         style="fill:none;stroke:#000000;stroke-width:3.75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2566" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath2830-0">
-      <path
-         d="M 1263.8515,1289.5536 1141.1078,1076.9552 1018.364,1289.5536 Z"
-         style="fill:none;stroke:#000000;stroke-width:3.75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2832-9" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath2834-1">
-      <path
-         d="M 1263.8515,1289.5536 1141.1078,1076.9552 1018.364,1289.5536 Z"
-         style="fill:none;stroke:#000000;stroke-width:3.75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2836-9" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath2830">
-      <path
-         d="M 1263.8515,1289.5536 1141.1078,1076.9552 1018.364,1289.5536 Z"
-         style="fill:none;stroke:#000000;stroke-width:3.75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2832" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath2834">
-      <path
-         d="M 1263.8515,1289.5536 1141.1078,1076.9552 1018.364,1289.5536 Z"
-         style="fill:none;stroke:#000000;stroke-width:3.75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         id="path2836-8" />
-    </clipPath>
-    <radialGradient
-       xlink:href="#linearGradient15756"
-       id="radialGradient15741"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,1.0000043,2.0716022,-484.75643)"
-       cx="166.00758"
-       cy="372.97809"
-       fx="166.00758"
-       fy="372.97809"
-       r="119.99949" />
-    <radialGradient
-       xlink:href="#linearGradient15756"
-       id="radialGradient1195"
-       cx="128"
-       cy="127.99902"
-       fx="128"
-       fy="127.99902"
-       r="128"
-       gradientTransform="matrix(1,0,0,1.0000076,0,-9.7655505e-4)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       xlink:href="#linearGradient1361"
-       id="linearGradient1363"
-       x1="105.84605"
-       y1="364.72827"
-       x2="282.53708"
-       y2="468.85712"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1403">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ff3200;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:18.75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 166.05664,297.09375 92.27344,159.82422 H 73.78125 Z"
-         id="path1405" />
-    </clipPath>
   </defs>
-  <metadata
-     id="metadata4380">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     transform="translate(-46.008093,-252.97808)"
-     id="layer1">
-    <path
-       style="fill:url(#radialGradient1195);fill-opacity:1.0;stroke:none;stroke-width:0.53324425;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-       d="M 115.58594 -0.001953125 L 90.853516 4.8808594 L 101.08008 38.773438 L 112.89648 18.306641 C 113.9566 16.471679 115.32192 14.882173 116.90234 13.576172 L 115.58594 -0.001953125 z M 140.79688 0.037109375 L 139.42383 13.767578 C 140.91171 15.039828 142.2017 16.563174 143.20898 18.306641 L 155.14844 38.986328 L 165.51562 4.9921875 L 140.79688 0.037109375 z M 67.546875 14.494141 L 46.564453 28.46875 L 82.013672 71.796875 L 90.363281 57.333984 L 67.546875 14.494141 z M 188.79102 14.673828 L 165.82617 57.482422 L 174.16211 71.921875 L 209.73047 28.712891 L 188.79102 14.673828 z M 28.712891 46.267578 L 14.673828 67.207031 L 68.113281 95.875 L 74.833984 84.234375 L 28.712891 46.267578 z M 227.53125 46.564453 L 181.3418 84.355469 L 188.06836 96.007812 L 241.50586 67.546875 L 227.53125 46.564453 z M 4.9921875 90.486328 L 0.037109375 115.20312 L 53.845703 120.58398 L 61.308594 107.66016 L 4.9921875 90.486328 z M 251.11914 90.851562 L 194.88672 107.81836 L 202.375 120.78711 L 256 115.58594 L 251.11914 90.851562 z M 44.912109 136.05859 L 0 140.41406 L 4.8808594 165.14648 L 33.019531 156.65625 L 44.912109 136.05859 z M 211.35156 136.33398 L 223.32422 157.07227 L 251.00781 165.51562 L 255.96289 140.79492 L 211.35156 136.33398 z M 14.738281 188.32031 L 14.494141 188.45117 L 14.583984 188.58789 L 14.738281 188.32031 z M 92.308594 245.03516 L 90.486328 251.00781 L 115.20312 255.96289 L 116.29688 245.03516 L 92.308594 245.03516 z M 139.35156 245.03516 L 140.41406 256 L 165.14648 251.11914 L 163.31055 245.03516 L 139.35156 245.03516 z "
-       id="path24-3-9-9-8-9"
-       transform="matrix(0.9375,0,0,0.9375,46.008093,252.97808)" />
-    <path
-       id="path2836"
-       style="fill:#f5f5f5;fill-opacity:1;stroke:#f02f00;stroke-width:20.625;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 274.5689,466.29363 166.0565,278.34459 57.544025,466.29363 Z" />
-    <path
-       id="path2836-3"
-       d="m 185.10609,331.95928 71.59977,124.01595 H 113.5048 Z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:14.54910278;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <path
-       id="path2836-3-6"
-       d="m 208.96672,373.2876 47.73914,82.68763 h -95.4793 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.70061398;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <path
-       id="path54-4"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.81467938;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-       d="m 137.63209,387.2185 c 2.86407,-1.12618 5.80583,-2.04414 8.802,-2.74706 12.18817,-2.85933 24.94736,-2.08181 36.69816,2.23658 2.44555,0.89875 4.83397,1.94604 7.15185,3.13594 6.4769,3.32484 12.3391,7.73037 17.33421,13.02692 -24.72737,28.18111 -68.55328,28.32965 -93.46034,0.32884 6.53576,-7.00848 14.55428,-12.47414 23.47412,-15.98122 z" />
-    <path
-       id="path40-0"
-       style="fill:#a0a0a0;fill-opacity:1;stroke:none;stroke-width:2.8176918;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-       d="m 207.41865,403.01014 c 2.88949,3.06403 5.47007,6.40543 7.70395,9.97587 -28.36704,24.99576 -71.53536,22.63396 -97.00599,-5.30736 25.78359,23.83368 66.14415,21.72368 89.30204,-4.66851 z" />
-    <path
-       id="path24-9"
-       style="fill:#19c5f1;fill-opacity:1;stroke:none;stroke-width:2.8176918;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-       d="m 162.2276,417.13375 c 15.40855,0.79949 28.22919,-11.70193 27.8284,-27.14492 -2.3105,-1.21069 -4.70146,-2.25898 -7.14958,-3.15861 -11.76339,-4.32316 -24.53631,-5.10154 -36.73748,-2.23904 -2.99939,0.70348 -5.9443,1.62242 -8.80711,2.71678 -2.00041,15.26511 9.45749,29.02628 24.86577,29.82579 z" />
-    <path
-       id="path52-2-6"
-       style="fill:#55d4f5;fill-opacity:1;stroke:none;stroke-width:0.8221091;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-       d="m 182.90173,386.84284 c 2.8385,12.50063 -7.12561,24.21199 -19.90766,23.40606 -12.78196,-0.806 -21.19616,-13.67636 -16.81599,-25.68296 12.19203,-2.83726 24.96495,-2.05888 36.72365,2.2769 z" />
-    <path
-       id="path44-1-5"
-       style="fill:#2b0000;fill-opacity:1;stroke:none;stroke-width:2.81780982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 215.1226,412.98601 c 2.30392,-2.03011 4.47046,-4.21118 6.48494,-6.52878 -24.0909,-40.00883 -81.51218,-41.63976 -107.78685,-3.08427 28.75003,-30.90323 78.93969,-26.1276 101.30191,9.61305 z" />
-    <circle
-       id="circle16"
-       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.28318477;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-       r="10.623326"
-       cy="-393.40286"
-       cx="164.09584"
-       transform="scale(1,-1)" />
-    <circle
-       r="5.4738908"
-       cy="389.7608"
-       cx="158.81535"
-       id="path4883-0-2"
-       style="opacity:1;fill:#ddf8ff;fill-opacity:1;stroke:none;stroke-width:1.99859631;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    <path
-       id="path2836-1"
-       style="fill:none;fill-opacity:1;stroke:url(#linearGradient1363);stroke-width:15;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 274.56891,466.29364 166.0565,278.34459 57.544023,466.29364 Z" />
-    <path
-       id="path2836-3-6-7"
-       d="m 232.44905,413.96069 24.25681,42.01454 h -48.51414 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#dadada;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.92899466;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+
+  <rect x="8" y="8" width="224" height="224" rx="52" fill="url(#cctvBg)"/>
+
+  <!-- streaming signal arcs -->
+  <g fill="none" stroke="#ffffff" stroke-width="7" stroke-linecap="round" opacity="0.9">
+    <path d="M150 66 a30 30 0 0 1 30 30"/>
+    <path d="M150 46 a50 50 0 0 1 50 50"/>
+  </g>
+
+  <!-- wall mount -->
+  <rect x="176" y="150" width="16" height="42" rx="6" fill="#ffffff"/>
+  <rect x="166" y="184" width="38" height="14" rx="6" fill="#ffffff"/>
+
+  <!-- camera, slightly tilted down -->
+  <g transform="rotate(-18 118 128)">
+    <!-- connector to mount -->
+    <rect x="170" y="116" width="30" height="24" rx="7" fill="#ffffff"/>
+    <!-- body -->
+    <rect x="50" y="104" width="134" height="48" rx="24" fill="url(#cctvBody)" stroke="#0c5f74" stroke-width="2"/>
+    <!-- sun shield -->
+    <rect x="46" y="95" width="98" height="18" rx="9" fill="#ffffff" stroke="#0c5f74" stroke-width="2"/>
+    <!-- lens -->
+    <circle cx="74" cy="128" r="21" fill="#0c3b48"/>
+    <circle cx="74" cy="128" r="12" fill="#12657a"/>
+    <circle cx="67" cy="121" r="4.5" fill="#bfeaf3"/>
   </g>
 </svg>

--- a/images/menu-sources.svg
+++ b/images/menu-sources.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="7" width="14" height="10" rx="2"/>
+  <path d="M16 10l6-3v10l-6-3z"/>
+  <circle cx="8" cy="12" r="2.2"/>
+</svg>

--- a/images/volume-mute.svg
+++ b/images/volume-mute.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="3 9 3 15 7 15 12 20 12 4 7 9 3 9" fill="#ffffff" stroke="none"/>
+  <line x1="16" y1="9" x2="22" y2="15"/>
+  <line x1="22" y1="9" x2="16" y2="15"/>
+</svg>

--- a/images/volume.svg
+++ b/images/volume.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="3 9 3 15 7 15 12 20 12 4 7 9 3 9" fill="#ffffff" stroke="none"/>
+  <path d="M16 8.5a4 4 0 0 1 0 7"/>
+  <path d="M19 5.5a8 8 0 0 1 0 13"/>
+</svg>

--- a/install-debian.sh
+++ b/install-debian.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Easy source install of CCTV Viewer on Debian / Ubuntu desktops (no snap).
+#
+# It installs the build and runtime dependencies, fetches the git submodules,
+# builds the application with CMake and installs it system-wide into /usr.
+#
+# Usage:
+#   ./install-debian.sh            # build and install
+#   ./install-debian.sh --uninstall
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+    SUDO="sudo"
+fi
+
+# Build dependencies (Qt 5, FFmpeg/libav, build tools).
+BUILD_DEPS=(
+    build-essential
+    cmake
+    git
+    pkg-config
+    libva-dev
+    libglx-dev
+    libavformat-dev
+    libavcodec-dev
+    libavutil-dev
+    libswscale-dev
+    libswresample-dev
+    libavdevice-dev
+    qtdeclarative5-dev
+    qtmultimedia5-dev
+    qttools5-dev
+)
+
+# Runtime QML modules and plugins needed at start-up.
+RUNTIME_DEPS=(
+    libqt5multimedia5-plugins
+    qtwayland5
+    qml-module-qtquick-layouts
+    qml-module-qtqml-models2
+    qml-module-qtquick-controls
+    qml-module-qtquick-controls2
+    qml-module-qtquick-templates2
+    qml-module-qtquick-window2
+    qml-module-qtquick-dialogs
+    qml-module-qt-labs-settings
+    qml-module-qtmultimedia
+    qml-module-qtgraphicaleffects
+)
+
+uninstall() {
+    echo ">> Uninstalling CCTV Viewer..."
+    if [ -f "${BUILD_DIR}/install_manifest.txt" ]; then
+        while IFS= read -r file; do
+            $SUDO rm -f "$file"
+        done < "${BUILD_DIR}/install_manifest.txt"
+    else
+        $SUDO rm -f /usr/bin/cctv-viewer \
+                    /usr/share/pixmaps/cctv-viewer.svg \
+                    /usr/share/applications/cctv-viewer.desktop
+    fi
+    $SUDO update-desktop-database /usr/share/applications 2>/dev/null || true
+    echo ">> Done."
+}
+
+if [ "${1:-}" = "--uninstall" ]; then
+    uninstall
+    exit 0
+fi
+
+echo ">> Installing build and runtime dependencies (apt)..."
+$SUDO apt-get update
+$SUDO apt-get install -y "${BUILD_DEPS[@]}" "${RUNTIME_DEPS[@]}"
+
+echo ">> Fetching git submodules..."
+git -C "${SCRIPT_DIR}" submodule update --init --recursive
+
+echo ">> Configuring (CMake)..."
+cmake -S "${SCRIPT_DIR}" -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+echo ">> Building..."
+cmake --build "${BUILD_DIR}" --parallel "$(nproc)"
+
+echo ">> Installing into /usr (requires privileges)..."
+$SUDO cmake --install "${BUILD_DIR}"
+
+echo ">> Refreshing desktop database and icon cache..."
+$SUDO update-desktop-database /usr/share/applications 2>/dev/null || true
+$SUDO gtk-update-icon-cache -f /usr/share/icons/hicolor 2>/dev/null || true
+
+echo ""
+echo ">> CCTV Viewer installed. Launch it from your application menu or run: cctv-viewer"

--- a/make-deb.sh
+++ b/make-deb.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Build a .deb package of CCTV Viewer for Debian / Ubuntu desktops (no snap).
+#
+# The resulting package is written to the parent directory and can be installed
+# with:  sudo apt install ../cctv-viewer_*.deb
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+    SUDO="sudo"
+fi
+
+PACKAGING_DEPS=(
+    devscripts
+    debhelper
+    dpkg-dev
+    build-essential
+    cmake
+    git
+    pkg-config
+    libva-dev
+    libglx-dev
+    libavformat-dev
+    libavcodec-dev
+    libavutil-dev
+    libswscale-dev
+    libswresample-dev
+    libavdevice-dev
+    qtdeclarative5-dev
+    qtmultimedia5-dev
+    qttools5-dev
+)
+
+echo ">> Installing packaging dependencies (apt)..."
+$SUDO apt-get update
+$SUDO apt-get install -y "${PACKAGING_DEPS[@]}"
+
+echo ">> Fetching git submodules..."
+git -C "${SCRIPT_DIR}" submodule update --init --recursive
+
+echo ">> Building the .deb package..."
+cd "${SCRIPT_DIR}"
+dpkg-buildpackage -us -uc -b
+
+echo ""
+echo ">> Package built. Install it with:"
+echo "     sudo apt install ../cctv-viewer_*.deb"

--- a/src/OnvifDialog.qml
+++ b/src/OnvifDialog.qml
@@ -1,0 +1,331 @@
+import QtQml 2.12
+import QtQuick 2.12
+import QtQuick.Layouts 1.12
+import QtQuick.Controls 2.12
+import QtQuick.Dialogs 1.3
+import CCTV_Viewer.Utils 1.0
+import CCTV_Viewer.Onvif 1.0
+
+Dialog {
+    id: root
+
+    title: qsTr("Add ONVIF device")
+    modality: Qt.ApplicationModal
+    standardButtons: StandardButton.Close
+
+    width: 460
+
+    property string statusMessage: ""
+
+    onVisibleChanged: {
+        if (visible) {
+            onvifDevice.reset();
+            discovery.reset();
+            statusMessage = "";
+            channelsModel.clear();
+        }
+    }
+
+    OnvifDevice {
+        id: onvifDevice
+
+        host: hostField.text
+        port: parseInt(portField.text) || 80
+        username: userField.text
+        password: passwordField.text
+
+        onErrorChanged: {
+            if (error !== "") {
+                root.statusMessage = error;
+            }
+        }
+        onChannelsChanged: {
+            channelsModel.clear();
+            for (var i = 0; i < channels.length; ++i) {
+                var ch = channels[i];
+                channelsModel.append({
+                    "name": ch.name,
+                    "mainUrl": ch.mainUrl,
+                    "subUrl": ch.subUrl ? ch.subUrl : "",
+                    "mainResolution": ch.mainResolution ? ch.mainResolution : "",
+                    "subResolution": ch.subResolution ? ch.subResolution : "",
+                    "selected": true
+                });
+            }
+            if (channelsModel.count > 0) {
+                root.statusMessage = qsTr("Found %1 channel(s).").arg(channelsModel.count);
+            }
+        }
+    }
+
+    OnvifDiscovery {
+        id: discovery
+    }
+
+    ListModel {
+        id: channelsModel
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 8
+
+        GroupBox {
+            title: qsTr("Device")
+
+            Layout.fillWidth: true
+
+            GridLayout {
+                columns: 2
+                anchors.fill: parent
+                columnSpacing: 8
+                rowSpacing: 6
+
+                Label { text: qsTr("Host / IP address:") }
+                TextField {
+                    id: hostField
+
+                    placeholderText: qsTr("192.168.1.10")
+                    selectByMouse: true
+                    Layout.fillWidth: true
+                }
+
+                Label { text: qsTr("Port:") }
+                TextField {
+                    id: portField
+
+                    text: "80"
+                    inputMethodHints: Qt.ImhDigitsOnly
+                    validator: IntValidator { bottom: 1; top: 65535 }
+                    selectByMouse: true
+                    Layout.preferredWidth: 90
+                }
+
+                Label { text: qsTr("Username:") }
+                TextField {
+                    id: userField
+
+                    text: "admin"
+                    selectByMouse: true
+                    Layout.fillWidth: true
+                }
+
+                Label { text: qsTr("Password:") }
+                TextField {
+                    id: passwordField
+
+                    echoMode: TextInput.Password
+                    selectByMouse: true
+                    Layout.fillWidth: true
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            Button {
+                text: discovery.scanning ? qsTr("Scanning…") : qsTr("Discover")
+                enabled: !discovery.scanning
+                onClicked: {
+                    root.statusMessage = qsTr("Scanning the local network…");
+                    discovery.scan(4000);
+                }
+            }
+
+            Button {
+                text: qsTr("Connect")
+                enabled: !onvifDevice.busy && hostField.text.trim() !== ""
+                onClicked: {
+                    root.statusMessage = qsTr("Connecting…");
+                    onvifDevice.fetchChannels();
+                }
+            }
+
+            BusyIndicator {
+                running: onvifDevice.busy || discovery.scanning
+                implicitWidth: 24
+                implicitHeight: 24
+                Layout.alignment: Qt.AlignVCenter
+            }
+
+            Item { Layout.fillWidth: true }
+        }
+
+        // Discovered devices
+        GroupBox {
+            title: qsTr("Discovered devices")
+            visible: discovery.devices.length > 0
+
+            Layout.fillWidth: true
+
+            Flow {
+                width: parent.width
+                spacing: 6
+
+                Repeater {
+                    model: discovery.devices
+
+                    Button {
+                        text: modelData.host + ":" + modelData.port
+                        onClicked: {
+                            hostField.text = modelData.host;
+                            portField.text = String(modelData.port);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Channels
+        GroupBox {
+            title: qsTr("Channels")
+
+            Layout.fillWidth: true
+
+            ColumnLayout {
+                anchors.fill: parent
+                spacing: 4
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    visible: channelsModel.count > 0
+
+                    Button {
+                        text: qsTr("Select all")
+                        onClicked: setAllSelected(true)
+                    }
+                    Button {
+                        text: qsTr("Select none")
+                        onClicked: setAllSelected(false)
+                    }
+                    Item { Layout.fillWidth: true }
+                }
+
+                ScrollView {
+                    clip: true
+
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 200
+                    Layout.minimumHeight: 120
+
+                    ListView {
+                        model: channelsModel
+                        spacing: 2
+
+                        delegate: RowLayout {
+                            width: ListView.view ? ListView.view.width : 0
+
+                            CheckBox {
+                                checked: model.selected
+                                onToggled: channelsModel.setProperty(index, "selected", checked)
+                            }
+
+                            ColumnLayout {
+                                spacing: 0
+                                Layout.fillWidth: true
+
+                                Label {
+                                    text: model.name
+                                    elide: Text.ElideRight
+                                    Layout.fillWidth: true
+                                }
+                                Label {
+                                    text: {
+                                        var s = model.mainResolution ? qsTr("main %1").arg(model.mainResolution) : qsTr("main stream");
+                                        if (model.subUrl) {
+                                            s += model.subResolution ? qsTr(", sub %1").arg(model.subResolution) : qsTr(", sub stream");
+                                        }
+                                        return s;
+                                    }
+                                    opacity: 0.6
+                                    font.pointSize: rootWindow.font.pointSize * 0.9
+                                    Layout.fillWidth: true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Label {
+            text: root.statusMessage
+            wrapMode: Text.WordWrap
+            visible: text !== ""
+
+            Layout.fillWidth: true
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            Item { Layout.fillWidth: true }
+
+            Button {
+                text: qsTr("Add selected to layout")
+                enabled: channelsModel.count > 0 && hasSelection()
+                highlighted: true
+                onClicked: addSelected()
+            }
+        }
+    }
+
+    function setAllSelected(value) {
+        for (var i = 0; i < channelsModel.count; ++i) {
+            channelsModel.setProperty(i, "selected", value);
+        }
+    }
+
+    function hasSelection() {
+        for (var i = 0; i < channelsModel.count; ++i) {
+            if (channelsModel.get(i).selected) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function addSelected() {
+        var layoutModel = Utils.currentModel();
+        var count = layoutModel.size.width * layoutModel.size.height;
+        var slot = 0;
+        var added = 0;
+
+        for (var c = 0; c < channelsModel.count; ++c) {
+            var ch = channelsModel.get(c);
+            if (!ch.selected) {
+                continue;
+            }
+
+            // Find the next empty viewport.
+            while (slot < count && String(layoutModel.get(slot).url) !== "") {
+                ++slot;
+            }
+            if (slot >= count) {
+                break;
+            }
+
+            layoutModel.get(slot).url = ch.mainUrl;
+            layoutModel.get(slot).subStreamUrl = ch.subUrl;
+            ++slot;
+            ++added;
+        }
+
+        if (added < countSelected()) {
+            root.statusMessage = qsTr("Added %1 channel(s). Not enough free viewports for the rest — increase the window division.").arg(added);
+        } else {
+            root.close();
+        }
+    }
+
+    function countSelected() {
+        var n = 0;
+        for (var i = 0; i < channelsModel.count; ++i) {
+            if (channelsModel.get(i).selected) {
+                ++n;
+            }
+        }
+        return n;
+    }
+}

--- a/src/OnvifDialog.qml
+++ b/src/OnvifDialog.qml
@@ -41,8 +41,12 @@ Dialog {
         }
         onChannelsChanged: {
             channelsModel.clear();
+            var subCount = 0;
             for (var i = 0; i < channels.length; ++i) {
                 var ch = channels[i];
+                if (ch.subUrl) {
+                    ++subCount;
+                }
                 channelsModel.append({
                     "name": ch.name,
                     "mainUrl": ch.mainUrl,
@@ -53,7 +57,13 @@ Dialog {
                 });
             }
             if (channelsModel.count > 0) {
-                root.statusMessage = qsTr("Found %1 channel(s).").arg(channelsModel.count);
+                if (subCount === channelsModel.count) {
+                    root.statusMessage = qsTr("Found %1 channel(s), each with a sub stream.").arg(channelsModel.count);
+                } else if (subCount > 0) {
+                    root.statusMessage = qsTr("Found %1 channel(s); %2 have a sub stream.").arg(channelsModel.count).arg(subCount);
+                } else {
+                    root.statusMessage = qsTr("Found %1 channel(s), but no sub streams were detected. Enable sub streams on the device for better grid performance, or set them manually.").arg(channelsModel.count);
+                }
             }
         }
     }

--- a/src/OnvifDialog.qml
+++ b/src/OnvifDialog.qml
@@ -152,6 +152,29 @@ Dialog {
             Item { Layout.fillWidth: true }
         }
 
+        RowLayout {
+            Layout.fillWidth: true
+
+            Label { text: qsTr("Subnet:") }
+
+            TextField {
+                id: subnetField
+
+                placeholderText: qsTr("192.168.1.0/24 or 10.0.0.1-10.0.0.50")
+                selectByMouse: true
+                Layout.fillWidth: true
+            }
+
+            Button {
+                text: qsTr("Scan subnet")
+                enabled: !discovery.scanning && subnetField.text.trim() !== ""
+                onClicked: {
+                    root.statusMessage = qsTr("Scanning subnet %1…").arg(subnetField.text.trim());
+                    discovery.scanSubnet(subnetField.text.trim(), 6000);
+                }
+            }
+        }
+
         // Discovered devices
         GroupBox {
             title: qsTr("Discovered devices")

--- a/src/Player.qml
+++ b/src/Player.qml
@@ -43,6 +43,12 @@ FocusScope {
             }
         } else {
             timer.stop();
+            // Remember the last frame before releasing the stream (e.g. the
+            // bandwidth saver stopping a hidden viewport) so it can be shown as
+            // a thumbnail when playback resumes.
+            if (qmlAvPlayer.status === MediaPlayer.Buffered) {
+                grabThumbnail();
+            }
             qmlAvPlayer.autoPlay = false;
             qmlAvPlayer.stop();
         }
@@ -60,13 +66,14 @@ FocusScope {
         }
     }
 
-    // Periodically remember the last displayed frame while the stream is
-    // playing so it can be used as a placeholder thumbnail when the stream is
-    // reloaded (grid <-> full-size/single view).
+    // Periodically refresh the remembered frame while the stream is playing so
+    // that if it drops and reconnects on its own we still have a recent frame
+    // to show. Source switches (grid <-> full-size) and stops are captured
+    // explicitly, so this only needs a coarse interval.
     Timer {
         id: thumbnailTimer
 
-        interval: 1000
+        interval: 2000
         repeat: true
         running: root.shouldPlay && qmlAvPlayer.status === MediaPlayer.Buffered
 

--- a/src/Player.qml
+++ b/src/Player.qml
@@ -22,6 +22,11 @@ FocusScope {
 
     readonly property bool shouldPlay: visible && active
 
+    // Holds the last frame grabbed from the video output. It is shown in place
+    // of a black rectangle while a new stream is loading (e.g. when switching
+    // between the grid and a full-size/single view swaps the stream source).
+    property var _lastFrame: null
+
     property alias loops: qmlAvPlayer.loops
     property alias source: qmlAvPlayer.source
     property alias muted: qmlAvPlayer.muted
@@ -55,6 +60,27 @@ FocusScope {
         }
     }
 
+    // Periodically remember the last displayed frame while the stream is
+    // playing so it can be used as a placeholder thumbnail when the stream is
+    // reloaded (grid <-> full-size/single view).
+    Timer {
+        id: thumbnailTimer
+
+        interval: 1000
+        repeat: true
+        running: root.shouldPlay && qmlAvPlayer.status === MediaPlayer.Buffered
+
+        onTriggered: root.grabThumbnail()
+    }
+
+    function grabThumbnail() {
+        videoOutput.grabToImage(function(result) {
+            if (result !== null) {
+                root._lastFrame = result;
+            }
+        });
+    }
+
     Rectangle {
         color: root.color
         border.color: "#101010"
@@ -66,6 +92,29 @@ FocusScope {
             source: qmlAvPlayer
             fillMode: root.fillMode
             anchors.fill: parent
+        }
+
+        // Last known frame, shown instead of a black rectangle while the new
+        // stream buffers after a source change.
+        Image {
+            id: thumbnail
+
+            anchors.fill: parent
+            cache: false
+            smooth: true
+            source: root._lastFrame ? root._lastFrame.url : ""
+            visible: source.toString() !== "" && qmlAvPlayer.status !== MediaPlayer.Buffered
+            fillMode: {
+                switch (root.fillMode) {
+                case VideoOutput.PreserveAspectCrop:
+                    return Image.PreserveAspectCrop;
+                case VideoOutput.Stretch:
+                    return Image.Stretch;
+                default:
+                    return Image.PreserveAspectFit;
+                }
+            }
+            clip: true
         }
 
 //        Rectangle {
@@ -115,6 +164,9 @@ FocusScope {
                     message.text = qsTr("Stalled");
                     break;
                 case MediaPlayer.Buffered:
+                    // Capture a fresh frame as soon as playback resumes so a
+                    // recent thumbnail is available for the next reload.
+                    root.grabThumbnail();
                     break;
                 case MediaPlayer.EndOfMedia:
                     message.text = qsTr("End of media");

--- a/src/Player.qml
+++ b/src/Player.qml
@@ -10,6 +10,12 @@ FocusScope {
 
     property var avOptions: ({})
 
+    // How the video is fitted into the viewport:
+    //   VideoOutput.PreserveAspectFit  - fit, keep aspect ratio (letterbox)
+    //   VideoOutput.PreserveAspectCrop - fill, keep aspect ratio (crop)
+    //   VideoOutput.Stretch            - stretch to fill
+    property int fillMode: VideoOutput.PreserveAspectFit
+
     property alias loops: qmlAvPlayer.loops
     property alias source: qmlAvPlayer.source
     property alias muted: qmlAvPlayer.muted
@@ -54,6 +60,7 @@ FocusScope {
             id: videoOutput
 
             source: qmlAvPlayer
+            fillMode: root.fillMode
             anchors.fill: parent
         }
 

--- a/src/Player.qml
+++ b/src/Player.qml
@@ -16,14 +16,23 @@ FocusScope {
     //   VideoOutput.Stretch            - stretch to fill
     property int fillMode: VideoOutput.PreserveAspectFit
 
+    // When false the stream is stopped and the network connection released.
+    // Used to pause hidden/background viewports to save bandwidth.
+    property bool active: true
+
+    readonly property bool shouldPlay: visible && active
+
     property alias loops: qmlAvPlayer.loops
     property alias source: qmlAvPlayer.source
     property alias muted: qmlAvPlayer.muted
     property alias volume: qmlAvPlayer.volume
     readonly property alias hasAudio: qmlAvPlayer.hasAudio
 
-    onVisibleChanged: {
-        if (visible) {
+    onShouldPlayChanged: updatePlayback()
+    Component.onCompleted: updatePlayback()
+
+    function updatePlayback() {
+        if (shouldPlay) {
             if (!timer.running) {
                 timer.start();
             }
@@ -33,11 +42,6 @@ FocusScope {
             qmlAvPlayer.stop();
         }
     }
-    Component.onCompleted: {
-        if (visible) {
-            timer.start();
-        }
-    }
 
     Timer {
         id: timer
@@ -45,7 +49,7 @@ FocusScope {
         interval: 50
 
         onTriggered: {
-            if (root.visible) {
+            if (root.shouldPlay) {
                 qmlAvPlayer.autoPlay = true;
             }
         }

--- a/src/RootWindow.qml
+++ b/src/RootWindow.qml
@@ -359,8 +359,24 @@ ApplicationWindow {
         standardButtons: MessageDialog.Ok
     }
 
+    // Appends a ".json" extension when the user typed a file name without one.
+    // defaultSuffix is not honoured by every platform's file dialog, so we
+    // enforce it here as well.
+    function ensureJsonSuffix(fileUrl) {
+        var url = fileUrl.toString();
+        var name = url.substring(url.lastIndexOf("/") + 1);
+
+        if (name.indexOf(".") === -1) {
+            url += ".json";
+        }
+
+        return url;
+    }
+
     // Batch export of every preset and its sources to a JSON file.
     function exportSources(fileUrl) {
+        fileUrl = rootWindow.ensureJsonSuffix(fileUrl);
+
         var data = {
             "version": 1,
             "presets": layoutsCollectionModel.toJSValue()

--- a/src/RootWindow.qml
+++ b/src/RootWindow.qml
@@ -115,6 +115,9 @@ ApplicationWindow {
         // 0 = Stretch, 1 = Fit (letterbox), 2 = Fill (crop). Default: Fill, so
         // streams auto-fit the tile without black bars in grid and full view.
         property int fillMode: 2
+        // Stop streaming the hidden viewports a few seconds after one goes full
+        // screen, to save network bandwidth.
+        property bool bandwidthSaver: true
     }
 
     Settings {

--- a/src/RootWindow.qml
+++ b/src/RootWindow.qml
@@ -111,6 +111,10 @@ ApplicationWindow {
         property bool unmuteWhenFullScreen: false
         // Master mute: silences every viewport without changing per-stream volume.
         property bool audioMuted: false
+        // Video fit mode applied to every viewport (VideoOutput.fillMode):
+        // 0 = Stretch, 1 = Fit (letterbox), 2 = Fill (crop). Default: Fill, so
+        // streams auto-fit the tile without black bars in grid and full view.
+        property int fillMode: 2
     }
 
     Settings {

--- a/src/RootWindow.qml
+++ b/src/RootWindow.qml
@@ -311,6 +311,87 @@ ApplicationWindow {
         id: settingsDialog
     }
 
+    OnvifDialog {
+        id: onvifDialog
+    }
+
+    FileIO {
+        id: fileIO
+    }
+
+    FileDialog {
+        id: exportDialog
+
+        title: qsTr("Export sources")
+        selectExisting: false
+        nameFilters: [qsTr("CCTV Viewer sources (*.json)"), qsTr("All files (*)")]
+        defaultSuffix: "json"
+
+        onAccepted: rootWindow.exportSources(fileUrl)
+    }
+
+    FileDialog {
+        id: importDialog
+
+        title: qsTr("Import sources")
+        selectExisting: true
+        nameFilters: [qsTr("CCTV Viewer sources (*.json)"), qsTr("All files (*)")]
+
+        onAccepted: rootWindow.importSources(fileUrl)
+    }
+
+    MessageDialog {
+        id: sourcesMessageDialog
+
+        standardButtons: MessageDialog.Ok
+    }
+
+    // Batch export of every preset and its sources to a JSON file.
+    function exportSources(fileUrl) {
+        var data = {
+            "version": 1,
+            "presets": layoutsCollectionModel.toJSValue()
+        };
+
+        if (!fileIO.write(fileUrl, JSON.stringify(data, null, 2))) {
+            sourcesMessageDialog.icon = StandardIcon.Critical;
+            sourcesMessageDialog.title = qsTr("Export failed");
+            sourcesMessageDialog.text = qsTr("Could not write the file: %1").arg(fileIO.error());
+            sourcesMessageDialog.open();
+        }
+    }
+
+    // Batch import that replaces the current presets/sources with those from a
+    // previously exported JSON file.
+    function importSources(fileUrl) {
+        var text = fileIO.read(fileUrl);
+
+        if (text.length === 0) {
+            sourcesMessageDialog.icon = StandardIcon.Critical;
+            sourcesMessageDialog.title = qsTr("Import failed");
+            sourcesMessageDialog.text = qsTr("Could not read the file: %1").arg(fileIO.error());
+            sourcesMessageDialog.open();
+            return;
+        }
+
+        try {
+            var data = JSON.parse(text);
+            var presets = (data.presets !== undefined) ? data.presets : data;
+
+            if (!(presets instanceof Array) || presets.length === 0) {
+                throw new Error(qsTr("The file does not contain any presets."));
+            }
+
+            layoutsCollectionModel.fromJSValue(presets);
+            stackLayout.currentIndex = stackLayout.currentIndex.clamp(0, layoutsCollectionModel.count - 1);
+        } catch(err) {
+            sourcesMessageDialog.icon = StandardIcon.Critical;
+            sourcesMessageDialog.title = qsTr("Import failed");
+            sourcesMessageDialog.text = qsTr("The file is not a valid sources file.");
+            sourcesMessageDialog.open();
+        }
+    }
+
     CursorShape {
         id: cursorShape
 

--- a/src/RootWindow.qml
+++ b/src/RootWindow.qml
@@ -109,6 +109,8 @@ ApplicationWindow {
         category: "Viewport"
 
         property bool unmuteWhenFullScreen: false
+        // Master mute: silences every viewport without changing per-stream volume.
+        property bool audioMuted: false
     }
 
     Settings {
@@ -137,6 +139,10 @@ ApplicationWindow {
                 }
             }
         }
+    }
+    Shortcut {
+        sequence: "Ctrl+M"
+        onActivated: viewportSettings.audioMuted = !viewportSettings.audioMuted
     }
     Shortcut {
         sequence: "Alt+Right"

--- a/src/SettingsDialog.qml
+++ b/src/SettingsDialog.qml
@@ -78,6 +78,23 @@ Dialog {
                     text: qsTr("Unmute when the viewport is in full screen mode")
                 }
 
+                RowLayout {
+                    Layout.fillWidth: true
+
+                    Label {
+                        text: qsTr("Video fit:")
+                    }
+
+                    ComboBox {
+                        id: videoFitComboBox
+
+                        // Index matches VideoOutput.fillMode: 0=Stretch, 1=Fit, 2=Fill.
+                        model: [qsTr("Stretch"), qsTr("Fit (letterbox)"), qsTr("Fill (crop)")]
+
+                        Layout.fillWidth: true
+                    }
+                }
+
                 Label {
                     text: qsTr("Default FFmpeg options")
                 }
@@ -151,6 +168,8 @@ Dialog {
 
         unmuteWhenFullScreenCheckBox.checked = viewportSettings.unmuteWhenFullScreen;
 
+        videoFitComboBox.currentIndex = viewportSettings.fillMode;
+
         carouselRunningCheckBox.checked = presetsSettings.carouselRunning;
         carouselIntervalSpinBox.value = presetsSettings.carouselInterval;
 
@@ -174,6 +193,8 @@ Dialog {
         viewSettings.hideCursorWhenFullScreen = hideCursorWhenFullScreenCheckBox.checked;
 
         viewportSettings.unmuteWhenFullScreen = unmuteWhenFullScreenCheckBox.checked;
+
+        viewportSettings.fillMode = videoFitComboBox.currentIndex;
 
         presetsSettings.carouselRunning = carouselRunningCheckBox.checked;
         presetsSettings.carouselInterval = carouselIntervalSpinBox.value;

--- a/src/SettingsDialog.qml
+++ b/src/SettingsDialog.qml
@@ -78,6 +78,12 @@ Dialog {
                     text: qsTr("Unmute when the viewport is in full screen mode")
                 }
 
+                CheckBox {
+                    id: bandwidthSaverCheckBox
+
+                    text: qsTr("Pause other streams in full screen mode (after 3s)")
+                }
+
                 RowLayout {
                     Layout.fillWidth: true
 
@@ -168,6 +174,8 @@ Dialog {
 
         unmuteWhenFullScreenCheckBox.checked = viewportSettings.unmuteWhenFullScreen;
 
+        bandwidthSaverCheckBox.checked = viewportSettings.bandwidthSaver;
+
         videoFitComboBox.currentIndex = viewportSettings.fillMode;
 
         carouselRunningCheckBox.checked = presetsSettings.carouselRunning;
@@ -193,6 +201,8 @@ Dialog {
         viewSettings.hideCursorWhenFullScreen = hideCursorWhenFullScreenCheckBox.checked;
 
         viewportSettings.unmuteWhenFullScreen = unmuteWhenFullScreenCheckBox.checked;
+
+        viewportSettings.bandwidthSaver = bandwidthSaverCheckBox.checked;
 
         viewportSettings.fillMode = videoFitComboBox.currentIndex;
 

--- a/src/SideBar.qml
+++ b/src/SideBar.qml
@@ -482,6 +482,28 @@ FocusScope {
                                     }
                                 }
 
+                                RowLayout {
+                                    Layout.fillWidth: true
+
+                                    Text {
+                                        text: qsTr("Volume")
+                                        color: "white"
+                                    }
+
+                                    Slider {
+                                        id: viewportVolumeSlider
+
+                                        enabled: currentViewportIndex >= 0 ? Utils.currentLayout().get(currentViewportIndex).hasAudio : false
+                                        from: 0
+                                        to: 1
+                                        value: enabled ? Utils.currentModel().get(currentViewportIndex).volume : 0
+
+                                        Layout.fillWidth: true
+
+                                        onMoved: Utils.currentModel().get(currentViewportIndex).volume = value
+                                    }
+                                }
+
 
                                 ColumnLayout {
                                     Layout.fillWidth: true
@@ -521,6 +543,67 @@ FocusScope {
                                             return Utils.stringifyOptions(options);
                                         }
 
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    SideBarItem {
+                        objectName: "sources"
+                        icon: "qrc:/images/menu-sources.svg"
+                        title: qsTr("Sources")
+
+                        Layout.fillWidth: true
+
+                        Frame {
+                            anchors.fill: parent
+
+                            ColumnLayout {
+                                anchors.fill: parent
+
+                                GroupBox {
+                                    title: qsTr("ONVIF")
+                                    palette.windowText: "white"
+
+                                    Layout.fillWidth: true
+
+                                    ColumnLayout {
+                                        anchors.fill: parent
+
+                                        Button {
+                                            text: qsTr("Add camera / NVR…")
+
+                                            Layout.fillWidth: true
+
+                                            onClicked: onvifDialog.open()
+                                        }
+                                    }
+                                }
+
+                                GroupBox {
+                                    title: qsTr("Batch")
+                                    palette.windowText: "white"
+
+                                    Layout.fillWidth: true
+
+                                    GridLayout {
+                                        columns: 2
+                                        anchors.fill: parent
+
+                                        Button {
+                                            text: qsTr("Import…")
+
+                                            Layout.fillWidth: true
+
+                                            onClicked: importDialog.open()
+                                        }
+                                        Button {
+                                            text: qsTr("Export…")
+
+                                            Layout.fillWidth: true
+
+                                            onClicked: exportDialog.open()
+                                        }
                                     }
                                 }
                             }

--- a/src/SideBar.qml
+++ b/src/SideBar.qml
@@ -188,9 +188,22 @@ FocusScope {
                                 }
 
                                 Text {
-                                    text: "<a href=\"https://github.com/iEvgeny/cctv-viewer\"><img src=\"qrc:/images/github.svg\" width=\"180\"></a>"
+                                    text: "<a href=\"https://github.com/jahedcuet/cctv-viewer\"><img src=\"qrc:/images/github.svg\" width=\"180\"></a>"
                                     color: "white"
                                     font.pointSize: rootWindow.font.pointSize * 1.05
+                                    textFormat: Text.RichText
+                                    horizontalAlignment: Text.AlignHCenter
+
+                                    Layout.fillWidth: true
+
+                                    onLinkHovered: header.linkHovered(link)
+                                    onLinkActivated: Qt.openUrlExternally(link)
+                                }
+
+                                Text {
+                                    text: "<a href=\"https://github.com/jahedcuet/cctv-viewer\" style=\"color: white; text-decoration: none;\">jahedcuet/cctv-viewer</a>"
+                                    color: "white"
+                                    font.pointSize: rootWindow.font.pointSize * 0.95
                                     textFormat: Text.RichText
                                     horizontalAlignment: Text.AlignHCenter
 
@@ -415,7 +428,7 @@ FocusScope {
 
                                 Layout.fillWidth: true
 
-                                RowLayout {
+                                ColumnLayout {
                                     anchors.fill: parent
 
                                     Button {
@@ -425,6 +438,15 @@ FocusScope {
                                         Layout.fillWidth: true
 
                                         onClicked: Utils.currentLayout().mergeCells()
+                                    }
+
+                                    Button {
+                                        text: viewportSettings.audioMuted ? qsTr("Unmute all") : qsTr("Mute all")
+                                        highlighted: viewportSettings.audioMuted
+
+                                        Layout.fillWidth: true
+
+                                        onClicked: viewportSettings.audioMuted = !viewportSettings.audioMuted
                                     }
                                 }
                             }
@@ -456,14 +478,36 @@ FocusScope {
                                 enabled: rootSideBar.currentViewportIndex >= 0
                                 anchors.fill: parent
 
+                                Text {
+                                    text: qsTr("Main stream")
+                                    color: "white"
+                                    font.pointSize: rootWindow.font.pointSize * 1.05
+                                }
+
                                 TextField {
                                     text: enabled ? Utils.currentModel().get(currentViewportIndex).url : ""
-                                    placeholderText: qsTr("Url")
+                                    placeholderText: qsTr("rtsp:// main stream URL")
                                     selectByMouse: true
 
                                     Layout.fillWidth: true
 
                                     onEditingFinished: Utils.currentModel().get(currentViewportIndex).url = text
+                                }
+
+                                Text {
+                                    text: qsTr("Sub stream")
+                                    color: "white"
+                                    font.pointSize: rootWindow.font.pointSize * 1.05
+                                }
+
+                                TextField {
+                                    text: enabled ? Utils.currentModel().get(currentViewportIndex).subStreamUrl : ""
+                                    placeholderText: qsTr("rtsp:// sub stream URL (optional)")
+                                    selectByMouse: true
+
+                                    Layout.fillWidth: true
+
+                                    onEditingFinished: Utils.currentModel().get(currentViewportIndex).subStreamUrl = text
                                 }
 
                                 Button {

--- a/src/ViewportsLayout.qml
+++ b/src/ViewportsLayout.qml
@@ -1,6 +1,7 @@
 import QtQml 2.12
 import QtQuick 2.12
 import QtQuick.Layouts 1.12
+import QtQuick.Controls 2.12
 import QtMultimedia 5.12
 import CCTV_Viewer.Core 1.0
 import CCTV_Viewer.Utils 1.0
@@ -185,6 +186,8 @@ FocusScope {
                     property int cursorColumnOffset: 0
                     property int cursorRowOffset: 0
                     property bool fullScreen: false
+                    // Remembers the last non-zero volume so the mute button can restore it.
+                    property real lastVolume: 0.5
                     
                     // Zoom properties
                     property real zoomScale: 1.0
@@ -195,6 +198,7 @@ FocusScope {
                     readonly property alias selected: d2.selected
 
                     readonly property alias url: d2.url
+                    readonly property alias subStreamUrl: d2.subStreamUrl
                     readonly property alias column: d2.column
                     readonly property alias row: d2.row
                     readonly property alias columnSpan: d2.columnSpan
@@ -372,6 +376,7 @@ FocusScope {
                         property bool selected: d.selectionContains(model.index)
 
                         property url url: model.url
+                        property url subStreamUrl: model.subStreamUrl
                         property int column: d.columnFromIndex(model.index)
                         property int row: d.rowFromIndex(model.index)
                         property int columnSpan: model.columnSpan
@@ -430,7 +435,16 @@ FocusScope {
                             id: player
 
                             color: root.color
-                            source: viewport.url
+                            // Auto adapt resolution: use the low-res sub stream in
+                            // grid view and switch to the main stream when the
+                            // viewport is maximized (full screen or single 1x1 view).
+                            source: {
+                                var sub = viewport.subStreamUrl.toString();
+                                if (!viewport.zoomEnabled && sub !== "") {
+                                    return viewport.subStreamUrl;
+                                }
+                                return viewport.url;
+                            }
                             volume: Math.max(viewport.volume, root.fullScreenIndex === index && viewportSettings.unmuteWhenFullScreen)
                             avOptions: viewport.avFormatOptions
                             loops: MediaPlayer.Infinite
@@ -577,6 +591,95 @@ FocusScope {
                         }
                     }
 
+                    // Per-viewport audio controls: a mute toggle and a volume
+                    // slider, shown on hover for every channel that has audio.
+                    Item {
+                        id: audioControls
+
+                        visible: viewport.hasAudio && !Context.config.kioskMode
+                        z: 5
+                        anchors.fill: parent
+
+                        readonly property bool active: hoverArea.containsMouse || volumeSlider.pressed
+                        readonly property bool muted: viewport.volume <= 0
+
+                        MouseArea {
+                            id: hoverArea
+
+                            acceptedButtons: Qt.NoButton
+                            hoverEnabled: true
+                            anchors.fill: parent
+                        }
+
+                        Rectangle {
+                            id: controlBar
+
+                            color: "#b0000000"
+                            radius: 4
+                            width: controlRow.implicitWidth + 12
+                            height: 26
+                            visible: opacity > 0
+                            opacity: audioControls.active ? 1 : 0
+                            anchors.left: parent.left
+                            anchors.bottom: parent.bottom
+                            anchors.margins: 6
+
+                            Behavior on opacity {
+                                NumberAnimation { duration: 150 }
+                            }
+
+                            Row {
+                                id: controlRow
+
+                                spacing: 4
+                                anchors.centerIn: parent
+
+                                Image {
+                                    id: muteIcon
+
+                                    width: 18
+                                    height: 18
+                                    sourceSize: Qt.size(18, 18)
+                                    source: audioControls.muted ? "qrc:/images/volume-mute.svg" : "qrc:/images/volume.svg"
+                                    anchors.verticalCenter: parent.verticalCenter
+
+                                    MouseArea {
+                                        enabled: audioControls.active
+                                        anchors.fill: parent
+                                        cursorShape: Qt.PointingHandCursor
+
+                                        onClicked: {
+                                            if (viewport.volume > 0) {
+                                                viewport.lastVolume = viewport.volume;
+                                                model.volume = 0;
+                                            } else {
+                                                model.volume = viewport.lastVolume > 0 ? viewport.lastVolume : 1;
+                                            }
+                                        }
+                                    }
+                                }
+
+                                Slider {
+                                    id: volumeSlider
+
+                                    enabled: audioControls.active
+                                    from: 0
+                                    to: 1
+                                    value: viewport.volume
+                                    width: 80
+                                    anchors.verticalCenter: parent.verticalCenter
+
+                                    onMoved: {
+                                        model.volume = value;
+                                        if (value > 0) {
+                                            viewport.lastVolume = value;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     function indexAt(x, y) {
                         for (var i = 0; i < repeater.count; ++i) {
                             var itemTo = repeater.itemAt(i);
@@ -609,6 +712,7 @@ FocusScope {
             for (var i = 0; i < root.size.width * root.size.height; ++i) {
                 if (root.get(i).selected) {
                     model.get(i).url = "";
+                    model.get(i).subStreamUrl = "";
                     model.get(i).volume = 0;
                     model.get(i).avFormatOptions = layoutsCollectionSettings.toJSValue("defaultAVFormatOptions");
                 }

--- a/src/ViewportsLayout.qml
+++ b/src/ViewportsLayout.qml
@@ -445,7 +445,7 @@ FocusScope {
                                 }
                                 return viewport.url;
                             }
-                            volume: Math.max(viewport.volume, root.fullScreenIndex === index && viewportSettings.unmuteWhenFullScreen)
+                            volume: viewportSettings.audioMuted ? 0 : Math.max(viewport.volume, root.fullScreenIndex === index && viewportSettings.unmuteWhenFullScreen)
                             avOptions: viewport.avFormatOptions
                             loops: MediaPlayer.Infinite
                             
@@ -588,6 +588,31 @@ FocusScope {
                                     d.selectionReset();
                                 }
                             }
+                        }
+                    }
+
+                    // Persistent badge that highlights which viewport is
+                    // currently generating sound.
+                    Rectangle {
+                        id: audioIndicator
+
+                        visible: viewport.hasAudio && !viewportSettings.audioMuted &&
+                                 (viewport.volume > 0 || (root.fullScreenIndex === index && viewportSettings.unmuteWhenFullScreen))
+                        z: 6
+                        width: 22
+                        height: 22
+                        radius: 4
+                        color: "#cc17a9ca"
+                        anchors.top: parent.top
+                        anchors.right: parent.right
+                        anchors.margins: 6
+
+                        Image {
+                            source: "qrc:/images/volume.svg"
+                            width: 14
+                            height: 14
+                            sourceSize: Qt.size(14, 14)
+                            anchors.centerIn: parent
                         }
                     }
 

--- a/src/ViewportsLayout.qml
+++ b/src/ViewportsLayout.qml
@@ -447,6 +447,7 @@ FocusScope {
                             }
                             volume: viewportSettings.audioMuted ? 0 : Math.max(viewport.volume, root.fullScreenIndex === index && viewportSettings.unmuteWhenFullScreen)
                             avOptions: viewport.avFormatOptions
+                            fillMode: viewportSettings.fillMode
                             loops: MediaPlayer.Infinite
                             
                             // Apply zoom transformation when zoom is enabled

--- a/src/ViewportsLayout.qml
+++ b/src/ViewportsLayout.qml
@@ -27,6 +27,9 @@ FocusScope {
 
         property real layoutRatio: (model.aspectRatio.width * model.size.width) / (model.aspectRatio.height * model.size.height);
         property int fullScreenIndex: -1
+        // Becomes true a few seconds after a viewport goes full screen so the
+        // other (hidden) viewports can stop streaming to save bandwidth.
+        property bool bandwidthSaveActive: false
         property int focusIndex: -1
         property int activeFocusIndex: -1
         property int pressAndHoldIndex: -1
@@ -37,6 +40,14 @@ FocusScope {
 
         onLayoutRatioChanged: selectionReset()
         onSelectionIndex1Changed: selectionReset()
+        onFullScreenIndexChanged: {
+            if (fullScreenIndex >= 0 && viewportSettings.bandwidthSaver) {
+                bandwidthSaveTimer.restart();
+            } else {
+                bandwidthSaveTimer.stop();
+                bandwidthSaveActive = false;
+            }
+        }
 
         function columnFromIndex(index) {
             return index % root.size.width;
@@ -125,6 +136,14 @@ FocusScope {
     Rectangle {
         color: root.color
         anchors.fill: parent
+    }
+
+    Timer {
+        id: bandwidthSaveTimer
+
+        interval: 3000
+
+        onTriggered: d.bandwidthSaveActive = true
     }
 
     GridLayout {
@@ -435,6 +454,9 @@ FocusScope {
                             id: player
 
                             color: root.color
+                            // Save bandwidth: once a viewport has been full screen
+                            // for a few seconds, stop streaming the hidden ones.
+                            active: d.fullScreenIndex < 0 || !d.bandwidthSaveActive || d.fullScreenIndex === index
                             // Auto adapt resolution: use the low-res sub stream in
                             // grid view and switch to the main stream when the
                             // viewport is maximized (full screen or single 1x1 view).

--- a/src/ViewportsLayout.qml
+++ b/src/ViewportsLayout.qml
@@ -276,6 +276,14 @@ FocusScope {
                         }
                     }
                     onZoomEnabledChanged: {
+                        // The stream source is swapped between the sub and main
+                        // stream when zoomEnabled toggles (grid <-> full-size).
+                        // Grab the frame that is currently on screen so it can be
+                        // shown as a placeholder while the new stream loads: the
+                        // sub-stream frame stretched up to full size when
+                        // entering, and the main-stream frame scaled down to fit
+                        // the cell when returning to the grid.
+                        player.grabThumbnail();
                         if (!zoomEnabled) {
                             resetZoom();
                         }

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1,0 +1,53 @@
+#include "fileio.h"
+
+#include <QFile>
+#include <QTextStream>
+
+QString FileIO::toLocalPath(const QUrl &fileUrl)
+{
+    if (fileUrl.isLocalFile()) {
+        return fileUrl.toLocalFile();
+    }
+    return fileUrl.toString();
+}
+
+QString FileIO::read(const QUrl &fileUrl)
+{
+    m_error.clear();
+
+    QFile file(toLocalPath(fileUrl));
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        m_error = file.errorString();
+        return QString();
+    }
+
+    QTextStream stream(&file);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    stream.setCodec("UTF-8");
+#endif
+    const QString content = stream.readAll();
+    file.close();
+
+    return content;
+}
+
+bool FileIO::write(const QUrl &fileUrl, const QString &text)
+{
+    m_error.clear();
+
+    QFile file(toLocalPath(fileUrl));
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        m_error = file.errorString();
+        return false;
+    }
+
+    QTextStream stream(&file);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    stream.setCodec("UTF-8");
+#endif
+    stream << text;
+    stream.flush();
+    file.close();
+
+    return true;
+}

--- a/src/fileio.h
+++ b/src/fileio.h
@@ -1,0 +1,31 @@
+#ifndef FILEIO_H
+#define FILEIO_H
+
+#include <QObject>
+#include <QString>
+#include <QUrl>
+
+// Minimal helper that lets QML read and write plain text files. Used to
+// implement batch import/export of the sources/presets configuration.
+class FileIO : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit FileIO(QObject *parent = nullptr) : QObject(parent) { }
+
+    // Reads the whole file and returns its contents. On failure returns an
+    // empty string and sets error().
+    Q_INVOKABLE QString read(const QUrl &fileUrl);
+    // Writes text to the file (truncating). Returns true on success.
+    Q_INVOKABLE bool write(const QUrl &fileUrl, const QString &text);
+
+    Q_INVOKABLE QString error() const { return m_error; }
+
+private:
+    static QString toLocalPath(const QUrl &fileUrl);
+
+    QString m_error;
+};
+
+#endif // FILEIO_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,8 @@
 #include "context.h"
 #include "eventfilter.h"
 #include "clipboard.h"
+#include "fileio.h"
+#include "onvif.h"
 #include "singleapplication.h"
 #include "context.h"
 #include "viewportslayoutscollectionmodel.h"
@@ -30,6 +32,9 @@ void registerQmlTypes()
     });
 
     qmlRegisterType<QmlAVPlayer>("CCTV_Viewer.Multimedia", 1, 0, "QmlAVPlayer");
+    qmlRegisterType<FileIO>("CCTV_Viewer.Utils", 1, 0, "FileIO");
+    qmlRegisterType<OnvifDevice>("CCTV_Viewer.Onvif", 1, 0, "OnvifDevice");
+    qmlRegisterType<OnvifDiscovery>("CCTV_Viewer.Onvif", 1, 0, "OnvifDiscovery");
     qmlRegisterType<ViewportsLayoutItem>("CCTV_Viewer.Models", 1, 0, "ViewportsLayoutItem");
     qmlRegisterType<ViewportsLayoutModel>("CCTV_Viewer.Models", 1, 0, "ViewportsLayoutModel");
     qmlRegisterType<ViewportsLayoutsCollectionModel>("CCTV_Viewer.Models", 1, 0, "ViewportsLayoutsCollectionModel");

--- a/src/onvif.cpp
+++ b/src/onvif.cpp
@@ -442,22 +442,10 @@ void OnvifDiscovery::reset()
     }
 }
 
-void OnvifDiscovery::scan(int timeoutMs)
+QByteArray OnvifDiscovery::buildProbe() const
 {
-    if (m_scanning) {
-        return;
-    }
-
-    reset();
-
-    m_socket->close();
-    if (!m_socket->bind(QHostAddress(QHostAddress::AnyIPv4), 0)) {
-        emit finished();
-        return;
-    }
-
     const QString messageId = QString("uuid:%1").arg(QUuid::createUuid().toString(QUuid::WithoutBraces));
-    const QByteArray probe = QString(
+    return QString(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         "<e:Envelope xmlns:e=\"http://www.w3.org/2003/05/soap-envelope\" "
         "xmlns:w=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" "
@@ -473,12 +461,125 @@ void OnvifDiscovery::scan(int timeoutMs)
         "</e:Body>"
         "</e:Envelope>")
         .arg(messageId).toUtf8();
+}
 
-    m_socket->writeDatagram(probe, QHostAddress("239.255.255.250"), 3702);
+void OnvifDiscovery::scan(int timeoutMs)
+{
+    if (m_scanning) {
+        return;
+    }
+
+    reset();
+
+    m_socket->close();
+    if (!m_socket->bind(QHostAddress(QHostAddress::AnyIPv4), 0)) {
+        emit finished();
+        return;
+    }
+
+    m_socket->writeDatagram(buildProbe(), QHostAddress("239.255.255.250"), 3702);
 
     m_scanning = true;
     emit scanningChanged();
     m_timer->start(timeoutMs);
+}
+
+void OnvifDiscovery::scanSubnet(const QString &subnet, int timeoutMs)
+{
+    if (m_scanning) {
+        return;
+    }
+
+    const QList<quint32> hosts = expandSubnet(subnet);
+    if (hosts.isEmpty()) {
+        emit finished();
+        return;
+    }
+
+    reset();
+
+    m_socket->close();
+    if (!m_socket->bind(QHostAddress(QHostAddress::AnyIPv4), 0)) {
+        emit finished();
+        return;
+    }
+
+    m_scanning = true;
+    emit scanningChanged();
+    m_timer->start(timeoutMs);
+
+    // Send a unicast probe to every host in the range. Devices reply directly
+    // to our socket, so this works across routed/remote subnets.
+    const QByteArray probe = buildProbe();
+    for (quint32 host : hosts) {
+        m_socket->writeDatagram(probe, QHostAddress(host), 3702);
+    }
+}
+
+QList<quint32> OnvifDiscovery::expandSubnet(const QString &subnet)
+{
+    QList<quint32> hosts;
+    const QString trimmed = subnet.trimmed();
+    if (trimmed.isEmpty()) {
+        return hosts;
+    }
+
+    // Cap the number of probed hosts to keep the scan bounded.
+    const int maxHosts = 2048;
+
+    if (trimmed.contains('/')) {
+        const QStringList parts = trimmed.split('/');
+        if (parts.size() != 2) {
+            return hosts;
+        }
+        QHostAddress base(parts.at(0));
+        bool ok = false;
+        const int prefix = parts.at(1).toInt(&ok);
+        if (base.isNull() || !ok || prefix < 0 || prefix > 32) {
+            return hosts;
+        }
+
+        const quint32 baseIp = base.toIPv4Address();
+        const quint32 mask = (prefix == 0) ? 0u : (0xFFFFFFFFu << (32 - prefix));
+        const quint32 network = baseIp & mask;
+        const quint32 broadcast = network | ~mask;
+
+        quint32 first = network;
+        quint32 last = broadcast;
+        if (prefix <= 30) {
+            // Skip the network and broadcast addresses for usable ranges.
+            first = network + 1;
+            last = broadcast - 1;
+        }
+        for (quint32 ip = first; ip <= last && hosts.size() < maxHosts; ++ip) {
+            hosts.append(ip);
+        }
+    } else if (trimmed.contains('-')) {
+        const QStringList parts = trimmed.split('-');
+        if (parts.size() != 2) {
+            return hosts;
+        }
+        QHostAddress from(parts.at(0).trimmed());
+        QHostAddress to(parts.at(1).trimmed());
+        if (from.isNull() || to.isNull()) {
+            return hosts;
+        }
+        quint32 first = from.toIPv4Address();
+        quint32 last = to.toIPv4Address();
+        if (last < first) {
+            qSwap(first, last);
+        }
+        for (quint32 ip = first; ip <= last && hosts.size() < maxHosts; ++ip) {
+            hosts.append(ip);
+        }
+    } else {
+        QHostAddress single(trimmed);
+        if (!single.isNull()) {
+            hosts.append(single.toIPv4Address());
+        }
+    }
+
+    return hosts;
 }
 
 void OnvifDiscovery::readResponses()

--- a/src/onvif.cpp
+++ b/src/onvif.cpp
@@ -1,5 +1,7 @@
 #include "onvif.h"
 
+#include <algorithm>
+
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QNetworkReply>
@@ -278,37 +280,56 @@ void OnvifDevice::buildChannels()
 {
     m_timeout->stop();
 
-    // Group profiles by their video source token. Each source is one physical
-    // camera (behind an NVR there is one source per channel).
-    QMap<QString, QList<Profile>> grouped;
-    QStringList order;
+    // Keep only the profiles that produced a playable URI.
+    QList<Profile> profiles;
     for (const Profile &p : m_profiles) {
-        if (p.uri.isEmpty()) {
-            continue;
+        if (!p.uri.isEmpty()) {
+            profiles.append(p);
         }
-        const QString key = p.sourceToken.isEmpty() ? p.token : p.sourceToken;
-        if (!grouped.contains(key)) {
-            order.append(key);
-        }
-        grouped[key].append(p);
     }
+    if (profiles.isEmpty()) {
+        fail(tr("No playable streams were returned by the device."));
+        return;
+    }
+
+    // Group profiles that belong to the same physical channel so a main and a
+    // sub stream can be paired. Different devices expose this differently, so we
+    // try several strategies in order of reliability.
+    QVector<QVector<int>> groups = groupProfiles(profiles);
 
     QVariantList channels;
     int channelNumber = 0;
-    for (const QString &key : order) {
-        QList<Profile> profiles = grouped.value(key);
+    for (const QVector<int> &group : groups) {
+        if (group.isEmpty()) {
+            continue;
+        }
 
         // Highest resolution profile is the main stream, lowest is the sub.
-        Profile main = profiles.first();
-        Profile sub = profiles.first();
-        for (const Profile &p : profiles) {
-            if (p.width * p.height > main.width * main.height) {
-                main = p;
+        int mainIdx = group.first();
+        int subIdx = group.first();
+        for (int idx : group) {
+            if (profileArea(profiles[idx]) > profileArea(profiles[mainIdx])) {
+                mainIdx = idx;
             }
-            if (p.width * p.height < sub.width * sub.height) {
-                sub = p;
+            if (profileArea(profiles[idx]) < profileArea(profiles[subIdx])) {
+                subIdx = idx;
             }
         }
+        // If every profile in the group has the same resolution the loop above
+        // leaves sub == main; pick any other profile as the sub stream so it is
+        // still used for the low-load grid view.
+        if (subIdx == mainIdx && group.size() >= 2) {
+            for (int idx : group) {
+                if (idx != mainIdx) {
+                    subIdx = idx;
+                    break;
+                }
+            }
+        }
+
+        const Profile &main = profiles[mainIdx];
+        const Profile &sub = profiles[subIdx];
+        const bool hasSub = (subIdx != mainIdx);
 
         ++channelNumber;
 
@@ -319,10 +340,10 @@ void OnvifDevice::buildChannels()
         }
         channel["name"] = name;
         channel["mainUrl"] = main.uri;
-        channel["subUrl"] = (sub.token != main.token) ? sub.uri : QString();
+        channel["subUrl"] = hasSub ? sub.uri : QString();
         channel["mainResolution"] = (main.width > 0 && main.height > 0)
                 ? QString("%1x%2").arg(main.width).arg(main.height) : QString();
-        channel["subResolution"] = (sub.token != main.token && sub.width > 0 && sub.height > 0)
+        channel["subResolution"] = (hasSub && sub.width > 0 && sub.height > 0)
                 ? QString("%1x%2").arg(sub.width).arg(sub.height) : QString();
         channels.append(channel);
     }
@@ -337,6 +358,90 @@ void OnvifDevice::buildChannels()
 
     setBusy(false);
     emit finished();
+}
+
+int OnvifDevice::profileArea(const Profile &p)
+{
+    return p.width * p.height;
+}
+
+QVector<QVector<int>> OnvifDevice::groupProfiles(const QList<Profile> &profiles)
+{
+    // Strategy 1: group by the video source, shared by the main and sub streams
+    // of one channel. Prefer the VideoSourceConfiguration token attribute and
+    // fall back to the SourceToken child.
+    {
+        QMap<QString, int> keyToGroup;
+        QVector<QVector<int>> groups;
+        bool usable = true;
+        for (int i = 0; i < profiles.size(); ++i) {
+            QString key = profiles[i].sourceConfigToken;
+            if (key.isEmpty()) {
+                key = profiles[i].sourceToken;
+            }
+            if (key.isEmpty()) {
+                usable = false;
+                break;
+            }
+            if (!keyToGroup.contains(key)) {
+                keyToGroup[key] = groups.size();
+                groups.append(QVector<int>());
+            }
+            groups[keyToGroup[key]].append(i);
+        }
+
+        int maxGroup = 0;
+        for (const QVector<int> &g : groups) {
+            maxGroup = std::max(maxGroup, int(g.size()));
+        }
+
+        // Only trust source-token grouping when it actually paired streams
+        // (some group has 2+ profiles) and did not collapse every channel into a
+        // single shared source. Otherwise fall through to name-based pairing.
+        if (usable && maxGroup >= 2 && !(groups.size() == 1 && profiles.size() > 3)) {
+            return groups;
+        }
+    }
+
+    // Strategy 2: classify each profile as main or sub from its name/token and
+    // pair them by order (devices list channels in a consistent order).
+    {
+        QVector<int> mains;
+        QVector<int> subs;
+        int unknown = 0;
+        for (int i = 0; i < profiles.size(); ++i) {
+            const QString s = (profiles[i].name + QLatin1Char(' ') + profiles[i].token).toLower();
+            const bool isSub = s.contains("sub") || s.contains("second") ||
+                               s.contains("minor") || s.contains("low");
+            const bool isMain = s.contains("main") || s.contains("primary") ||
+                                s.contains("first") || s.contains("high");
+            if (isSub && !isMain) {
+                subs.append(i);
+            } else if (isMain && !isSub) {
+                mains.append(i);
+            } else {
+                ++unknown;
+            }
+        }
+        if (unknown == 0 && !mains.isEmpty() && mains.size() == subs.size()) {
+            QVector<QVector<int>> groups;
+            for (int k = 0; k < mains.size(); ++k) {
+                QVector<int> pair;
+                pair.append(mains[k]);
+                pair.append(subs[k]);
+                groups.append(pair);
+            }
+            return groups;
+        }
+    }
+
+    // Strategy 3: give up on pairing and expose every profile as its own
+    // channel (the user can still set a sub stream manually).
+    QVector<QVector<int>> groups;
+    for (int i = 0; i < profiles.size(); ++i) {
+        groups.append(QVector<int>{i});
+    }
+    return groups;
 }
 
 void OnvifDevice::setBusy(bool busy)
@@ -409,6 +514,8 @@ QList<OnvifDevice::Profile> OnvifDevice::parseProfiles(const QByteArray &xml)
             } else if (inProfile) {
                 if (name == QLatin1String("Name") && current.name.isEmpty()) {
                     current.name = reader.readElementText();
+                } else if (name == QLatin1String("VideoSourceConfiguration")) {
+                    current.sourceConfigToken = reader.attributes().value("token").toString();
                 } else if (name == QLatin1String("SourceToken")) {
                     current.sourceToken = reader.readElementText();
                 } else if (name == QLatin1String("Width") && current.width == 0) {

--- a/src/onvif.cpp
+++ b/src/onvif.cpp
@@ -3,6 +3,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QNetworkReply>
+#include <QAuthenticator>
 #include <QUdpSocket>
 #include <QHostAddress>
 #include <QTimer>
@@ -29,6 +30,23 @@ OnvifDevice::OnvifDevice(QObject *parent)
         if (m_busy) {
             fail(tr("Connection timed out."));
         }
+    });
+
+    // Many ONVIF devices (e.g. Hikvision) protect the service endpoints with
+    // HTTP Basic/Digest authentication in addition to the WS-UsernameToken in
+    // the SOAP header. Answer that HTTP challenge with the same credentials.
+    connect(m_nam, &QNetworkAccessManager::authenticationRequired, this,
+            [this]([[maybe_unused]] QNetworkReply *reply, QAuthenticator *authenticator) {
+        if (m_username.isEmpty()) {
+            return;
+        }
+        // Only supply the credentials once per request; if they are already set
+        // the previous attempt failed and retrying would loop.
+        if (authenticator->user() == m_username) {
+            return;
+        }
+        authenticator->setUser(m_username);
+        authenticator->setPassword(m_password);
     });
 }
 
@@ -115,7 +133,9 @@ QString OnvifDevice::soapHeader() const
     }
 
     const QByteArray nonce = QUuid::createUuid().toRfc4122();
-    const QString created = QDateTime::currentDateTimeUtc().toString(Qt::ISODate) + "Z";
+    // NOTE: A UTC QDateTime already renders a trailing "Z" with Qt::ISODate, so
+    // build the timestamp explicitly to avoid a malformed "...ZZ" value.
+    const QString created = QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddTHH:mm:ss'Z'");
 
     QByteArray digestSource;
     digestSource.append(nonce);

--- a/src/onvif.cpp
+++ b/src/onvif.cpp
@@ -1,0 +1,538 @@
+#include "onvif.h"
+
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QUdpSocket>
+#include <QHostAddress>
+#include <QTimer>
+#include <QUrl>
+#include <QUuid>
+#include <QDateTime>
+#include <QCryptographicHash>
+#include <QXmlStreamReader>
+#include <QStringList>
+#include <QMap>
+
+// ---------------------------------------------------------------------------
+// OnvifDevice
+// ---------------------------------------------------------------------------
+
+OnvifDevice::OnvifDevice(QObject *parent)
+    : QObject(parent)
+    , m_nam(new QNetworkAccessManager(this))
+    , m_timeout(new QTimer(this))
+{
+    m_timeout->setSingleShot(true);
+    m_timeout->setInterval(15000);
+    connect(m_timeout, &QTimer::timeout, this, [this] {
+        if (m_busy) {
+            fail(tr("Connection timed out."));
+        }
+    });
+}
+
+void OnvifDevice::setHost(const QString &host)
+{
+    if (m_host == host) {
+        return;
+    }
+    m_host = host;
+    emit hostChanged();
+}
+
+void OnvifDevice::setPort(int port)
+{
+    if (m_port == port) {
+        return;
+    }
+    m_port = port;
+    emit portChanged();
+}
+
+void OnvifDevice::setUsername(const QString &username)
+{
+    if (m_username == username) {
+        return;
+    }
+    m_username = username;
+    emit usernameChanged();
+}
+
+void OnvifDevice::setPassword(const QString &password)
+{
+    if (m_password == password) {
+        return;
+    }
+    m_password = password;
+    emit passwordChanged();
+}
+
+void OnvifDevice::reset()
+{
+    m_timeout->stop();
+    m_mediaXAddr.clear();
+    m_profiles.clear();
+    m_pendingStreamUri = 0;
+    setError(QString());
+    if (!m_channels.isEmpty()) {
+        m_channels.clear();
+        emit channelsChanged();
+    }
+    setBusy(false);
+}
+
+void OnvifDevice::fetchChannels()
+{
+    if (m_busy) {
+        return;
+    }
+    if (m_host.trimmed().isEmpty()) {
+        setError(tr("Host address is empty."));
+        return;
+    }
+
+    reset();
+    setBusy(true);
+    m_timeout->start();
+    requestCapabilities();
+}
+
+QString OnvifDevice::deviceServiceUrl() const
+{
+    return QString("http://%1:%2/onvif/device_service").arg(m_host).arg(m_port);
+}
+
+QString OnvifDevice::mediaFallbackUrl() const
+{
+    return QString("http://%1:%2/onvif/media_service").arg(m_host).arg(m_port);
+}
+
+QString OnvifDevice::soapHeader() const
+{
+    if (m_username.isEmpty()) {
+        return QString();
+    }
+
+    const QByteArray nonce = QUuid::createUuid().toRfc4122();
+    const QString created = QDateTime::currentDateTimeUtc().toString(Qt::ISODate) + "Z";
+
+    QByteArray digestSource;
+    digestSource.append(nonce);
+    digestSource.append(created.toUtf8());
+    digestSource.append(m_password.toUtf8());
+    const QByteArray digest = QCryptographicHash::hash(digestSource, QCryptographicHash::Sha1);
+
+    return QString(
+        "<s:Header>"
+        "<Security s:mustUnderstand=\"1\" xmlns=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">"
+        "<UsernameToken>"
+        "<Username>%1</Username>"
+        "<Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest\">%2</Password>"
+        "<Nonce EncodingType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary\">%3</Nonce>"
+        "<Created xmlns=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">%4</Created>"
+        "</UsernameToken>"
+        "</Security>"
+        "</s:Header>")
+        .arg(m_username.toHtmlEscaped(),
+             QString::fromLatin1(digest.toBase64()),
+             QString::fromLatin1(nonce.toBase64()),
+             created);
+}
+
+QNetworkReply *OnvifDevice::post(const QString &url, const QString &action, const QString &body)
+{
+    const QString envelope = QString(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<s:Envelope xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\">"
+        "%1<s:Body>%2</s:Body>"
+        "</s:Envelope>")
+        .arg(soapHeader(), body);
+
+    QNetworkRequest request((QUrl(url)));
+    request.setHeader(QNetworkRequest::ContentTypeHeader,
+                      QString("application/soap+xml; charset=utf-8; action=\"%1\"").arg(action));
+
+    return m_nam->post(request, envelope.toUtf8());
+}
+
+void OnvifDevice::requestCapabilities()
+{
+    const QString body =
+        "<GetCapabilities xmlns=\"http://www.onvif.org/ver10/device/wsdl\">"
+        "<Category>Media</Category>"
+        "</GetCapabilities>";
+
+    QNetworkReply *reply = post(deviceServiceUrl(),
+                                "http://www.onvif.org/ver10/device/wsdl/GetCapabilities", body);
+    connect(reply, &QNetworkReply::finished, this, [this, reply] {
+        reply->deleteLater();
+
+        if (reply->error() == QNetworkReply::NoError) {
+            m_mediaXAddr = parseMediaXAddr(reply->readAll());
+        }
+        if (m_mediaXAddr.isEmpty()) {
+            // Fall back to the conventional media endpoint.
+            m_mediaXAddr = mediaFallbackUrl();
+        }
+
+        requestProfiles();
+    });
+}
+
+void OnvifDevice::requestProfiles()
+{
+    m_timeout->start();
+
+    const QString body = "<GetProfiles xmlns=\"http://www.onvif.org/ver10/media/wsdl\"/>";
+    QNetworkReply *reply = post(m_mediaXAddr,
+                                "http://www.onvif.org/ver10/media/wsdl/GetProfiles", body);
+    connect(reply, &QNetworkReply::finished, this, [this, reply] {
+        reply->deleteLater();
+
+        if (reply->error() != QNetworkReply::NoError) {
+            fail(tr("Failed to get media profiles: %1").arg(reply->errorString()));
+            return;
+        }
+
+        m_profiles = parseProfiles(reply->readAll());
+        if (m_profiles.isEmpty()) {
+            fail(tr("No media profiles found. Check the credentials."));
+            return;
+        }
+
+        m_pendingStreamUri = m_profiles.size();
+        for (int i = 0; i < m_profiles.size(); ++i) {
+            requestStreamUri(i);
+        }
+    });
+}
+
+void OnvifDevice::requestStreamUri(int profileIndex)
+{
+    m_timeout->start();
+
+    const QString body = QString(
+        "<GetStreamUri xmlns=\"http://www.onvif.org/ver10/media/wsdl\">"
+        "<StreamSetup xmlns=\"http://www.onvif.org/ver10/schema\">"
+        "<Stream>RTP-Unicast</Stream>"
+        "<Transport><Protocol>RTSP</Protocol></Transport>"
+        "</StreamSetup>"
+        "<ProfileToken>%1</ProfileToken>"
+        "</GetStreamUri>")
+        .arg(m_profiles.at(profileIndex).token.toHtmlEscaped());
+
+    QNetworkReply *reply = post(m_mediaXAddr,
+                                "http://www.onvif.org/ver10/media/wsdl/GetStreamUri", body);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, profileIndex] {
+        reply->deleteLater();
+
+        if (reply->error() == QNetworkReply::NoError && profileIndex < m_profiles.size()) {
+            const QString uri = parseStreamUri(reply->readAll());
+            m_profiles[profileIndex].uri = injectCredentials(uri);
+        }
+
+        if (--m_pendingStreamUri <= 0) {
+            buildChannels();
+        }
+    });
+}
+
+QString OnvifDevice::injectCredentials(const QString &rtspUri) const
+{
+    if (rtspUri.isEmpty() || m_username.isEmpty()) {
+        return rtspUri;
+    }
+
+    QUrl url(rtspUri);
+    if (!url.isValid()) {
+        return rtspUri;
+    }
+    url.setUserName(m_username);
+    url.setPassword(m_password);
+
+    return url.toString(QUrl::FullyEncoded);
+}
+
+void OnvifDevice::buildChannels()
+{
+    m_timeout->stop();
+
+    // Group profiles by their video source token. Each source is one physical
+    // camera (behind an NVR there is one source per channel).
+    QMap<QString, QList<Profile>> grouped;
+    QStringList order;
+    for (const Profile &p : m_profiles) {
+        if (p.uri.isEmpty()) {
+            continue;
+        }
+        const QString key = p.sourceToken.isEmpty() ? p.token : p.sourceToken;
+        if (!grouped.contains(key)) {
+            order.append(key);
+        }
+        grouped[key].append(p);
+    }
+
+    QVariantList channels;
+    int channelNumber = 0;
+    for (const QString &key : order) {
+        QList<Profile> profiles = grouped.value(key);
+
+        // Highest resolution profile is the main stream, lowest is the sub.
+        Profile main = profiles.first();
+        Profile sub = profiles.first();
+        for (const Profile &p : profiles) {
+            if (p.width * p.height > main.width * main.height) {
+                main = p;
+            }
+            if (p.width * p.height < sub.width * sub.height) {
+                sub = p;
+            }
+        }
+
+        ++channelNumber;
+
+        QVariantMap channel;
+        QString name = main.name;
+        if (name.isEmpty()) {
+            name = tr("Channel %1").arg(channelNumber);
+        }
+        channel["name"] = name;
+        channel["mainUrl"] = main.uri;
+        channel["subUrl"] = (sub.token != main.token) ? sub.uri : QString();
+        channel["mainResolution"] = (main.width > 0 && main.height > 0)
+                ? QString("%1x%2").arg(main.width).arg(main.height) : QString();
+        channel["subResolution"] = (sub.token != main.token && sub.width > 0 && sub.height > 0)
+                ? QString("%1x%2").arg(sub.width).arg(sub.height) : QString();
+        channels.append(channel);
+    }
+
+    if (channels.isEmpty()) {
+        fail(tr("No playable streams were returned by the device."));
+        return;
+    }
+
+    m_channels = channels;
+    emit channelsChanged();
+
+    setBusy(false);
+    emit finished();
+}
+
+void OnvifDevice::setBusy(bool busy)
+{
+    if (m_busy == busy) {
+        return;
+    }
+    m_busy = busy;
+    emit busyChanged();
+}
+
+void OnvifDevice::setError(const QString &error)
+{
+    if (m_error == error) {
+        return;
+    }
+    m_error = error;
+    emit errorChanged();
+}
+
+void OnvifDevice::fail(const QString &error)
+{
+    m_timeout->stop();
+    m_pendingStreamUri = 0;
+    setError(error);
+    setBusy(false);
+    emit finished();
+}
+
+QString OnvifDevice::parseMediaXAddr(const QByteArray &xml)
+{
+    QXmlStreamReader reader(xml);
+    bool inMedia = false;
+
+    while (!reader.atEnd()) {
+        reader.readNext();
+        const QString name = reader.name().toString();
+
+        if (reader.isStartElement()) {
+            if (name == QLatin1String("Media")) {
+                inMedia = true;
+            } else if (inMedia && name == QLatin1String("XAddr")) {
+                return reader.readElementText();
+            }
+        } else if (reader.isEndElement() && name == QLatin1String("Media")) {
+            inMedia = false;
+        }
+    }
+
+    return QString();
+}
+
+QList<OnvifDevice::Profile> OnvifDevice::parseProfiles(const QByteArray &xml)
+{
+    QList<Profile> profiles;
+    QXmlStreamReader reader(xml);
+
+    bool inProfile = false;
+    Profile current;
+
+    while (!reader.atEnd()) {
+        reader.readNext();
+        const QString name = reader.name().toString();
+
+        if (reader.isStartElement()) {
+            if (name == QLatin1String("Profiles")) {
+                inProfile = true;
+                current = Profile();
+                current.token = reader.attributes().value("token").toString();
+            } else if (inProfile) {
+                if (name == QLatin1String("Name") && current.name.isEmpty()) {
+                    current.name = reader.readElementText();
+                } else if (name == QLatin1String("SourceToken")) {
+                    current.sourceToken = reader.readElementText();
+                } else if (name == QLatin1String("Width") && current.width == 0) {
+                    current.width = reader.readElementText().toInt();
+                } else if (name == QLatin1String("Height") && current.height == 0) {
+                    current.height = reader.readElementText().toInt();
+                }
+            }
+        } else if (reader.isEndElement() && name == QLatin1String("Profiles") && inProfile) {
+            profiles.append(current);
+            inProfile = false;
+        }
+    }
+
+    return profiles;
+}
+
+QString OnvifDevice::parseStreamUri(const QByteArray &xml)
+{
+    QXmlStreamReader reader(xml);
+
+    while (!reader.atEnd()) {
+        reader.readNext();
+        if (reader.isStartElement() && reader.name() == QLatin1String("Uri")) {
+            return reader.readElementText();
+        }
+    }
+
+    return QString();
+}
+
+// ---------------------------------------------------------------------------
+// OnvifDiscovery
+// ---------------------------------------------------------------------------
+
+OnvifDiscovery::OnvifDiscovery(QObject *parent)
+    : QObject(parent)
+    , m_socket(new QUdpSocket(this))
+    , m_timer(new QTimer(this))
+{
+    m_timer->setSingleShot(true);
+    connect(m_timer, &QTimer::timeout, this, &OnvifDiscovery::stop);
+    connect(m_socket, &QUdpSocket::readyRead, this, &OnvifDiscovery::readResponses);
+}
+
+void OnvifDiscovery::reset()
+{
+    if (!m_devices.isEmpty()) {
+        m_devices.clear();
+        emit devicesChanged();
+    }
+}
+
+void OnvifDiscovery::scan(int timeoutMs)
+{
+    if (m_scanning) {
+        return;
+    }
+
+    reset();
+
+    m_socket->close();
+    if (!m_socket->bind(QHostAddress(QHostAddress::AnyIPv4), 0)) {
+        emit finished();
+        return;
+    }
+
+    const QString messageId = QString("uuid:%1").arg(QUuid::createUuid().toString(QUuid::WithoutBraces));
+    const QByteArray probe = QString(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<e:Envelope xmlns:e=\"http://www.w3.org/2003/05/soap-envelope\" "
+        "xmlns:w=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" "
+        "xmlns:d=\"http://schemas.xmlsoap.org/ws/2005/04/discovery\" "
+        "xmlns:dn=\"http://www.onvif.org/ver10/network/wsdl\">"
+        "<e:Header>"
+        "<w:MessageID>%1</w:MessageID>"
+        "<w:To e:mustUnderstand=\"true\">urn:schemas-xmlsoap-org:ws:2005:04:discovery</w:To>"
+        "<w:Action e:mustUnderstand=\"true\">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</w:Action>"
+        "</e:Header>"
+        "<e:Body>"
+        "<d:Probe><d:Types>dn:NetworkVideoTransmitter</d:Types></d:Probe>"
+        "</e:Body>"
+        "</e:Envelope>")
+        .arg(messageId).toUtf8();
+
+    m_socket->writeDatagram(probe, QHostAddress("239.255.255.250"), 3702);
+
+    m_scanning = true;
+    emit scanningChanged();
+    m_timer->start(timeoutMs);
+}
+
+void OnvifDiscovery::readResponses()
+{
+    while (m_socket->hasPendingDatagrams()) {
+        QByteArray datagram;
+        datagram.resize(int(m_socket->pendingDatagramSize()));
+        m_socket->readDatagram(datagram.data(), datagram.size());
+
+        QXmlStreamReader reader(datagram);
+        while (!reader.atEnd()) {
+            reader.readNext();
+            if (reader.isStartElement() && reader.name() == QLatin1String("XAddrs")) {
+                const QString xaddrs = reader.readElementText();
+                // XAddrs may contain several whitespace-separated URLs.
+                const QStringList urls = xaddrs.simplified().split(QChar(' '));
+                for (const QString &url : urls) {
+                    if (!url.isEmpty()) {
+                        addDevice(url);
+                    }
+                }
+            }
+        }
+    }
+}
+
+void OnvifDiscovery::addDevice(const QString &xaddr)
+{
+    QUrl url(xaddr);
+    if (!url.isValid() || url.host().isEmpty()) {
+        return;
+    }
+
+    for (const QVariant &existing : m_devices) {
+        if (existing.toMap().value("host").toString() == url.host()) {
+            return;
+        }
+    }
+
+    QVariantMap device;
+    device["host"] = url.host();
+    device["port"] = url.port(80);
+    device["xaddr"] = xaddr;
+    m_devices.append(device);
+    emit devicesChanged();
+}
+
+void OnvifDiscovery::stop()
+{
+    if (!m_scanning) {
+        return;
+    }
+    m_socket->close();
+    m_scanning = false;
+    emit scanningChanged();
+    emit finished();
+}

--- a/src/onvif.h
+++ b/src/onvif.h
@@ -120,8 +120,14 @@ public:
     bool scanning() const { return m_scanning; }
     QVariantList devices() const { return m_devices; }
 
-    // Scans the local network for the given number of milliseconds.
+    // Scans the local network (multicast WS-Discovery) for the given number of
+    // milliseconds.
     Q_INVOKABLE void scan(int timeoutMs = 4000);
+    // Scans an arbitrary subnet by sending unicast WS-Discovery probes to every
+    // host in the range, so devices on remote/routed subnets can be found too.
+    // Accepts CIDR ("192.168.5.0/24"), a range ("192.168.5.10-192.168.5.60") or
+    // a single address.
+    Q_INVOKABLE void scanSubnet(const QString &subnet, int timeoutMs = 6000);
     Q_INVOKABLE void reset();
 
 signals:
@@ -135,6 +141,8 @@ private slots:
 
 private:
     void addDevice(const QString &xaddr);
+    QByteArray buildProbe() const;
+    static QList<quint32> expandSubnet(const QString &subnet);
 
     QUdpSocket *m_socket;
     QTimer *m_timer;

--- a/src/onvif.h
+++ b/src/onvif.h
@@ -1,0 +1,145 @@
+#ifndef ONVIF_H
+#define ONVIF_H
+
+#include <QObject>
+#include <QVariantList>
+#include <QList>
+#include <QString>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+class QUdpSocket;
+class QTimer;
+
+// Represents a single ONVIF device (a camera, or an NVR/DVR that exposes many
+// channels behind one IP address). It queries the ONVIF Media service and
+// groups the returned media profiles by their video source into "channels".
+// Every physical camera behind an NVR is a separate video source, so grouping
+// by source token gives one entry per camera, while the highest/lowest
+// resolution profiles of a source become its main/sub streams.
+class OnvifDevice : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString host READ host WRITE setHost NOTIFY hostChanged)
+    Q_PROPERTY(int port READ port WRITE setPort NOTIFY portChanged)
+    Q_PROPERTY(QString username READ username WRITE setUsername NOTIFY usernameChanged)
+    Q_PROPERTY(QString password READ password WRITE setPassword NOTIFY passwordChanged)
+    Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
+    Q_PROPERTY(QString error READ error NOTIFY errorChanged)
+    Q_PROPERTY(QVariantList channels READ channels NOTIFY channelsChanged)
+
+public:
+    explicit OnvifDevice(QObject *parent = nullptr);
+
+    QString host() const { return m_host; }
+    void setHost(const QString &host);
+    int port() const { return m_port; }
+    void setPort(int port);
+    QString username() const { return m_username; }
+    void setUsername(const QString &username);
+    QString password() const { return m_password; }
+    void setPassword(const QString &password);
+    bool busy() const { return m_busy; }
+    QString error() const { return m_error; }
+    QVariantList channels() const { return m_channels; }
+
+    // Connects to the device and asynchronously builds the channel list.
+    // The result is delivered through the channelsChanged() signal.
+    Q_INVOKABLE void fetchChannels();
+    // Clears the current result and any error.
+    Q_INVOKABLE void reset();
+
+signals:
+    void hostChanged();
+    void portChanged();
+    void usernameChanged();
+    void passwordChanged();
+    void busyChanged();
+    void errorChanged();
+    void channelsChanged();
+    void finished();
+
+private:
+    struct Profile {
+        QString token;
+        QString name;
+        QString sourceToken;
+        int width = 0;
+        int height = 0;
+        QString uri;
+    };
+
+    QString deviceServiceUrl() const;
+    QString mediaFallbackUrl() const;
+    QString soapHeader() const;
+    QNetworkReply *post(const QString &url, const QString &action, const QString &body);
+    QString injectCredentials(const QString &rtspUri) const;
+
+    void requestCapabilities();
+    void requestProfiles();
+    void requestStreamUri(int profileIndex);
+    void buildChannels();
+
+    void setBusy(bool busy);
+    void setError(const QString &error);
+    void fail(const QString &error);
+
+    static QList<Profile> parseProfiles(const QByteArray &xml);
+    static QString parseMediaXAddr(const QByteArray &xml);
+    static QString parseStreamUri(const QByteArray &xml);
+
+    QNetworkAccessManager *m_nam;
+    QTimer *m_timeout;
+
+    QString m_host;
+    int m_port = 80;
+    QString m_username;
+    QString m_password;
+    bool m_busy = false;
+    QString m_error;
+    QVariantList m_channels;
+
+    QString m_mediaXAddr;
+    QList<Profile> m_profiles;
+    int m_pendingStreamUri = 0;
+};
+
+// Best-effort WS-Discovery probe. Sends a multicast Probe and collects the
+// service addresses (XAddrs) advertised by ONVIF devices on the local network.
+class OnvifDiscovery : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool scanning READ scanning NOTIFY scanningChanged)
+    Q_PROPERTY(QVariantList devices READ devices NOTIFY devicesChanged)
+
+public:
+    explicit OnvifDiscovery(QObject *parent = nullptr);
+
+    bool scanning() const { return m_scanning; }
+    QVariantList devices() const { return m_devices; }
+
+    // Scans the local network for the given number of milliseconds.
+    Q_INVOKABLE void scan(int timeoutMs = 4000);
+    Q_INVOKABLE void reset();
+
+signals:
+    void scanningChanged();
+    void devicesChanged();
+    void finished();
+
+private slots:
+    void readResponses();
+    void stop();
+
+private:
+    void addDevice(const QString &xaddr);
+
+    QUdpSocket *m_socket;
+    QTimer *m_timer;
+    bool m_scanning = false;
+    QVariantList m_devices;
+};
+
+#endif // ONVIF_H

--- a/src/onvif.h
+++ b/src/onvif.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QVariantList>
 #include <QList>
+#include <QVector>
 #include <QString>
 
 class QNetworkAccessManager;
@@ -64,7 +65,8 @@ private:
     struct Profile {
         QString token;
         QString name;
-        QString sourceToken;
+        QString sourceToken;        // <tt:SourceToken> child of VideoSourceConfiguration
+        QString sourceConfigToken;  // token attribute of VideoSourceConfiguration
         int width = 0;
         int height = 0;
         QString uri;
@@ -80,6 +82,9 @@ private:
     void requestProfiles();
     void requestStreamUri(int profileIndex);
     void buildChannels();
+
+    static int profileArea(const Profile &p);
+    static QVector<QVector<int>> groupProfiles(const QList<Profile> &profiles);
 
     void setBusy(bool busy);
     void setError(const QString &error);

--- a/src/viewportslayoutmodel.h
+++ b/src/viewportslayoutmodel.h
@@ -22,6 +22,7 @@ public:
     Q_ENUM(Visible)
 
     QMLAV_PROPERTY(QString, url, setUrl, urlChanged);
+    QMLAV_PROPERTY(QString, subStreamUrl, setSubStreamUrl, subStreamUrlChanged);
     QMLAV_PROPERTY(int, rowSpan, setRowSpan, rowSpanChanged) = 1;
     QMLAV_PROPERTY(int, columnSpan, setColumnSpan, columnSpanChanged) = 1;
     QMLAV_PROPERTY(ViewportsLayoutItem::Visible, visible, setVisible, visibleChanged) = Visible::Visible;


### PR DESCRIPTION
ONVIF
- New OnvifDevice/OnvifDiscovery C++ classes (src/onvif.*): WS-Discovery
  scan of the local network and SOAP GetCapabilities/GetProfiles/GetStreamUri
  with WS-UsernameToken digest auth. Profiles are grouped by video source so
  each physical camera behind an NVR/DVR (multiple channels on one IP) becomes
  a channel with main/sub RTSP URIs.
- OnvifDialog.qml: discover or manually enter host/port/credentials, list the
  detected channels with their resolutions, and add the selected ones to the
  free viewports of the current preset.

Auto adapt resolution
- ViewportsLayoutItem gains a subStreamUrl. The player uses the low-res sub
  stream in grid view and switches to the main stream when a viewport is
  maximized (full screen or single 1x1 view).

Audio
- Per-viewport on-screen mute toggle and volume slider shown on hover for
  every audio-capable channel, plus a volume slider in the sidebar viewport
  panel. New volume/volume-mute icons.

Batch import/export
- FileIO helper (src/fileio.*) plus RootWindow import/export of all presets
  and sources to a JSON file via file dialogs, reachable from a new sidebar
  "Sources" section.

Snap-free Debian install
- install-debian.sh (deps + submodules + CMake build/install) and
  make-deb.sh (.deb build), documented in the README. debian/control gains the
  qtgraphicaleffects and templates2 QML modules that were already used.

Build wiring: register FileIO/OnvifDevice/OnvifDiscovery QML types, add Qt
Network, add new sources to CMake, and add the QML/images to the resources.
